### PR TITLE
Enhancements based on testing with BSC and Polygon

### DIFF
--- a/config.md
+++ b/config.md
@@ -91,8 +91,8 @@ nav_order: 2
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
 |blockTimestamps|Whether to include the block timestamps in the event information|`boolean`|`true`
-|catchupPageSize|Number of blocks to query per poll when catching up to the head of the blockchain|`int`|`5000`
-|catchupThreshold|How many blocks behind the chain head an event stream or listener must be on startup, to enter catchup mode|`int`|`5000`
+|catchupPageSize|Number of blocks to query per poll when catching up to the head of the blockchain|`int`|`2500`
+|catchupThreshold|How many blocks behind the chain head an event stream or listener must be on startup, to enter catchup mode|`int`|`2500`
 |checkpointBlockGap|The number of blocks at the head of the chain that should be considered unstable (could be dropped from the canonical chain after a re-org). Unless events with a full set of confirmations are detected, the restart checkpoint will this many blocks behind the chain head.|`int`|`50`
 |filterPollingInterval|The interval between polling calls to a filter, when checking for newly arrived events|[`time.Duration`](https://pkg.go.dev/time#Duration)|`1s`
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hyperledger/firefly-common v0.1.20
 	github.com/hyperledger/firefly-signer v0.9.13
-	github.com/hyperledger/firefly-transaction-manager v0.9.5
+	github.com/hyperledger/firefly-transaction-manager v0.9.6-0.20220822183009-d8c012ede5aa
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hyperledger/firefly-common v0.1.20
 	github.com/hyperledger/firefly-signer v0.9.13
-	github.com/hyperledger/firefly-transaction-manager v0.9.6-0.20220822183009-d8c012ede5aa
+	github.com/hyperledger/firefly-transaction-manager v0.9.6
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.4.0
 	github.com/stretchr/testify v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/hyperledger/firefly-common v0.1.20 h1:0dShkjlIShyBxkXRmu3vLmpEK6xrqmf
 github.com/hyperledger/firefly-common v0.1.20/go.mod h1:gMlv4Iy5JjnzXmSEdb+tWVDIc/2GhL9MRcgNX+VmI4M=
 github.com/hyperledger/firefly-signer v0.9.13 h1:yvKxYTsEmE0XWl0vcZBQV353YmmePvWwIPMr4Lie67o=
 github.com/hyperledger/firefly-signer v0.9.13/go.mod h1:GPQRUZOFOAjkLmg8GDjZUjEdUD0gcar+CSVhwltIwyw=
-github.com/hyperledger/firefly-transaction-manager v0.9.6-0.20220822183009-d8c012ede5aa h1:503z4kEfFtaHKqVwWil+2pm+2cX1v9+cJrQtGdNCOl4=
-github.com/hyperledger/firefly-transaction-manager v0.9.6-0.20220822183009-d8c012ede5aa/go.mod h1:GuwXVVXI6p3tNk99jbYi4PopMzipVBwy3uu5wSKXJEc=
+github.com/hyperledger/firefly-transaction-manager v0.9.6 h1:mX2CN82wbq0izm0ANZxMAjsBeEnzeQy9xWUtsQd6N5Y=
+github.com/hyperledger/firefly-transaction-manager v0.9.6/go.mod h1:GuwXVVXI6p3tNk99jbYi4PopMzipVBwy3uu5wSKXJEc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,8 @@ github.com/hyperledger/firefly-common v0.1.20 h1:0dShkjlIShyBxkXRmu3vLmpEK6xrqmf
 github.com/hyperledger/firefly-common v0.1.20/go.mod h1:gMlv4Iy5JjnzXmSEdb+tWVDIc/2GhL9MRcgNX+VmI4M=
 github.com/hyperledger/firefly-signer v0.9.13 h1:yvKxYTsEmE0XWl0vcZBQV353YmmePvWwIPMr4Lie67o=
 github.com/hyperledger/firefly-signer v0.9.13/go.mod h1:GPQRUZOFOAjkLmg8GDjZUjEdUD0gcar+CSVhwltIwyw=
-github.com/hyperledger/firefly-transaction-manager v0.9.5 h1:fKJ4xv2DsYydQgkR4oZ/SrZD7E4Z4CZqjlQHLQPtwNE=
-github.com/hyperledger/firefly-transaction-manager v0.9.5/go.mod h1:GuwXVVXI6p3tNk99jbYi4PopMzipVBwy3uu5wSKXJEc=
+github.com/hyperledger/firefly-transaction-manager v0.9.6-0.20220822183009-d8c012ede5aa h1:503z4kEfFtaHKqVwWil+2pm+2cX1v9+cJrQtGdNCOl4=
+github.com/hyperledger/firefly-transaction-manager v0.9.6-0.20220822183009-d8c012ede5aa/go.mod h1:GuwXVVXI6p3tNk99jbYi4PopMzipVBwy3uu5wSKXJEc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=

--- a/go.sum
+++ b/go.sum
@@ -293,8 +293,6 @@ github.com/hyperledger/firefly-common v0.1.20 h1:0dShkjlIShyBxkXRmu3vLmpEK6xrqmf
 github.com/hyperledger/firefly-common v0.1.20/go.mod h1:gMlv4Iy5JjnzXmSEdb+tWVDIc/2GhL9MRcgNX+VmI4M=
 github.com/hyperledger/firefly-signer v0.9.13 h1:yvKxYTsEmE0XWl0vcZBQV353YmmePvWwIPMr4Lie67o=
 github.com/hyperledger/firefly-signer v0.9.13/go.mod h1:GPQRUZOFOAjkLmg8GDjZUjEdUD0gcar+CSVhwltIwyw=
-github.com/hyperledger/firefly-transaction-manager v0.9.4 h1:/0mqyDZXXOs7z1VbajmTYiKp1riaYZi8NFQm2ut7b5g=
-github.com/hyperledger/firefly-transaction-manager v0.9.4/go.mod h1:GuwXVVXI6p3tNk99jbYi4PopMzipVBwy3uu5wSKXJEc=
 github.com/hyperledger/firefly-transaction-manager v0.9.5 h1:fKJ4xv2DsYydQgkR4oZ/SrZD7E4Z4CZqjlQHLQPtwNE=
 github.com/hyperledger/firefly-transaction-manager v0.9.5/go.mod h1:GuwXVVXI6p3tNk99jbYi4PopMzipVBwy3uu5wSKXJEc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/internal/ethereum/blocklistener_test.go
+++ b/internal/ethereum/blocklistener_test.go
@@ -67,11 +67,17 @@ func TestBlockListenerStartGettingHighestBlockFailBeforeStop(t *testing.T) {
 
 }
 
-func TestBlockListenerOK(t *testing.T) {
+func TestBlockListenerOKSequential(t *testing.T) {
 
 	_, c, mRPC, done := newTestConnector(t)
 	bl := c.blockListener
 	bl.blockPollingInterval = 1 * time.Microsecond
+	bl.unstableHeadLength = 2 // check wrapping
+
+	block1000Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1001Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
 
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*ethtypes.HexInteger)
@@ -84,37 +90,43 @@ func TestBlockListenerOK(t *testing.T) {
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
 		*hbh = []ethtypes.HexBytes0xPrefix{
-			ethtypes.MustNewHexBytes0xPrefix("0x936feb38eae37a1083a995a33795d952ae502017bb749d2566ed5ad0cb3b49e1"),
-			ethtypes.MustNewHexBytes0xPrefix("0x67e48f436893ff6b1bd5303a14dad1f4981441b2990e72d31dc2678faa55f38c"),
+			block1001Hash,
+			block1002Hash,
 		}
 	}).Once()
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
 		*hbh = []ethtypes.HexBytes0xPrefix{
-			ethtypes.MustNewHexBytes0xPrefix("0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42"),
+			block1003Hash,
 		}
 	}).Once()
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
 
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
-		return bh == "0x936feb38eae37a1083a995a33795d952ae502017bb749d2566ed5ad0cb3b49e1"
+		return bh == block1001Hash.String()
 	}), false).Return(nil).Run(func(args mock.Arguments) {
 		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
-			Number: ethtypes.NewHexInteger64(1001),
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
 		}
 	})
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
-		return bh == "0x67e48f436893ff6b1bd5303a14dad1f4981441b2990e72d31dc2678faa55f38c"
+		return bh == block1002Hash.String()
 	}), false).Return(nil).Run(func(args mock.Arguments) {
 		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
-			Number: ethtypes.NewHexInteger64(1002),
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002Hash,
+			ParentHash: block1001Hash,
 		}
 	})
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
-		return bh == "0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42"
+		return bh == block1003Hash.String()
 	}), false).Return(nil).Run(func(args mock.Arguments) {
 		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
-			Number: ethtypes.NewHexInteger64(1003),
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003Hash,
+			ParentHash: block1002Hash,
 		}
 	})
 
@@ -127,12 +139,586 @@ func TestBlockListenerOK(t *testing.T) {
 
 	bu := <-updates
 	assert.Equal(t, []string{
-		"0x936feb38eae37a1083a995a33795d952ae502017bb749d2566ed5ad0cb3b49e1",
-		"0x67e48f436893ff6b1bd5303a14dad1f4981441b2990e72d31dc2678faa55f38c",
+		block1001Hash.String(),
+		block1002Hash.String(),
 	}, bu.BlockHashes)
 	bu = <-updates
 	assert.Equal(t, []string{
-		"0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42",
+		block1003Hash.String(),
+	}, bu.BlockHashes)
+	assert.False(t, bu.GapPotential)
+
+	done()
+	<-bl.listenLoopDone
+
+	assert.Equal(t, int64(1003), bl.highestBlock)
+
+	mRPC.AssertExpectations(t)
+
+	assert.Equal(t, bl.unstableHeadLength, bl.canonicalChain.Len())
+
+}
+
+func TestBlockListenerOKDuplicates(t *testing.T) {
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.blockPollingInterval = 1 * time.Microsecond
+
+	block1000Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1001Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*ethtypes.HexInteger)
+		*hbh = *ethtypes.NewHexInteger64(1000)
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_newBlockFilter").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*string)
+		*hbh = "filter_id1"
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1001Hash,
+			block1002Hash,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1003Hash,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1002Hash,
+			block1003Hash,
+		}
+		go done() // once we've detected these duplicates, we can close
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1001Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1002Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002Hash,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003Hash,
+			ParentHash: block1002Hash,
+		}
+	})
+
+	updates := make(chan *ffcapi.BlockHashEvent)
+	bl.addConsumer(&blockUpdateConsumer{
+		id:      fftypes.NewUUID(),
+		ctx:     context.Background(),
+		updates: updates,
+	})
+
+	bu := <-updates
+	assert.Equal(t, []string{
+		block1001Hash.String(),
+		block1002Hash.String(),
+	}, bu.BlockHashes)
+	bu = <-updates
+	assert.Equal(t, []string{
+		block1003Hash.String(),
+	}, bu.BlockHashes)
+	assert.False(t, bu.GapPotential)
+
+	<-bl.listenLoopDone
+
+	assert.Equal(t, int64(1003), bl.highestBlock)
+
+	mRPC.AssertExpectations(t)
+
+}
+
+func TestBlockListenerReorgReplaceTail(t *testing.T) {
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.blockPollingInterval = 1 * time.Microsecond
+
+	block1000Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1001Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*ethtypes.HexInteger)
+		*hbh = *ethtypes.NewHexInteger64(1000)
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_newBlockFilter").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*string)
+		*hbh = "filter_id1"
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1001Hash,
+			block1002Hash,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1003HashA,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1003HashB,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1001Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1002Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002Hash,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003HashA.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashA,
+			ParentHash: block1002Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003HashB.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashB,
+			ParentHash: block1002Hash,
+		}
+	})
+
+	updates := make(chan *ffcapi.BlockHashEvent)
+	bl.addConsumer(&blockUpdateConsumer{
+		id:      fftypes.NewUUID(),
+		ctx:     context.Background(),
+		updates: updates,
+	})
+
+	bu := <-updates
+	assert.Equal(t, []string{
+		block1001Hash.String(),
+		block1002Hash.String(),
+	}, bu.BlockHashes)
+	bu = <-updates
+	assert.Equal(t, []string{
+		block1003HashA.String(),
+	}, bu.BlockHashes)
+	assert.False(t, bu.GapPotential)
+	bu = <-updates
+	assert.Equal(t, []string{
+		block1003HashB.String(),
+	}, bu.BlockHashes)
+	assert.False(t, bu.GapPotential)
+
+	done()
+	<-bl.listenLoopDone
+
+	assert.Equal(t, int64(1003), bl.highestBlock)
+
+	mRPC.AssertExpectations(t)
+
+}
+
+func TestBlockListenerGap(t *testing.T) {
+
+	// See issue https://github.com/hyperledger/firefly-evmconnect/issues/10
+	// We have seen that certain JSON/RPC endpoints might miss blocks during re-orgs, and our listener
+	// needs to cope with this. This means winding back when we find a gap and re-building our canonical
+	// view of the chain.
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.blockPollingInterval = 1 * time.Microsecond
+
+	block1000Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1001Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1004Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1005Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*ethtypes.HexInteger)
+		*hbh = *ethtypes.NewHexInteger64(1000)
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_newBlockFilter").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*string)
+		*hbh = "filter_id1"
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1001Hash,
+			block1002HashA,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1004Hash,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1001Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1002HashA.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002HashA,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1004Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1004),
+			Hash:       block1004Hash,
+			ParentHash: block1003Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1001
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1002
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002HashB,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1003
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003Hash,
+			ParentHash: block1002HashB,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1004
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1004),
+			Hash:       block1004Hash,
+			ParentHash: block1003Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1005
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1005), // this one pops in while we're rebuilding
+			Hash:       block1005Hash,
+			ParentHash: block1004Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1006 // not found
+	}), false).Return(nil)
+
+	updates := make(chan *ffcapi.BlockHashEvent)
+	bl.addConsumer(&blockUpdateConsumer{
+		id:      fftypes.NewUUID(),
+		ctx:     context.Background(),
+		updates: updates,
+	})
+
+	bu := <-updates
+	assert.Equal(t, []string{
+		block1001Hash.String(),
+		block1002HashA.String(),
+	}, bu.BlockHashes)
+	bu = <-updates
+	assert.Equal(t, []string{
+		block1002HashB.String(),
+		block1003Hash.String(), // The gap we filled in
+		block1004Hash.String(),
+		block1005Hash.String(), // Appeared while we were rebuilding our chain
+	}, bu.BlockHashes)
+	assert.False(t, bu.GapPotential)
+
+	done()
+	<-bl.listenLoopDone
+
+	assert.Equal(t, int64(1005), bl.highestBlock)
+
+	mRPC.AssertExpectations(t)
+
+}
+
+func TestBlockListenerReorgWhileRebuilding(t *testing.T) {
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.blockPollingInterval = 1 * time.Microsecond
+
+	block1000Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1001Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*ethtypes.HexInteger)
+		*hbh = *ethtypes.NewHexInteger64(1000)
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_newBlockFilter").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*string)
+		*hbh = "filter_id1"
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1001Hash,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1003HashA,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1001Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003HashA.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashA,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1001
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1002
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002HashA,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1003
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashB, // this is a re-org'd block, so we stop here as if we've found the end of the chain
+			ParentHash: block1002HashB,
+		}
+	})
+
+	updates := make(chan *ffcapi.BlockHashEvent)
+	bl.addConsumer(&blockUpdateConsumer{
+		id:      fftypes.NewUUID(),
+		ctx:     context.Background(),
+		updates: updates,
+	})
+
+	bu := <-updates
+	assert.Equal(t, []string{
+		block1001Hash.String(),
+	}, bu.BlockHashes)
+	bu = <-updates
+	assert.Equal(t, []string{
+		block1002HashA.String(),
+	}, bu.BlockHashes)
+
+	done()
+	<-bl.listenLoopDone
+
+	assert.Equal(t, int64(1003), bl.highestBlock)
+
+	mRPC.AssertExpectations(t)
+
+}
+
+func TestBlockListenerReorgReplaceWholeCanonicalChain(t *testing.T) {
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.blockPollingInterval = 1 * time.Microsecond
+
+	block1001Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*ethtypes.HexInteger)
+		*hbh = *ethtypes.NewHexInteger64(1000)
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_newBlockFilter").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*string)
+		*hbh = "filter_id1"
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1002HashA,
+			block1003HashA,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1003HashB,
+		}
+	}).Once()
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1002HashA.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002HashA,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003HashA.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashA,
+			ParentHash: block1002HashA,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003HashB.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashB,
+			ParentHash: block1002HashB,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1002
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002HashB,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1003
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashB,
+			ParentHash: block1002HashB,
+		}
+	})
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.MatchedBy(func(bn *ethtypes.HexInteger) bool {
+		return bn.BigInt().Int64() == 1004 // not found
+	}), false).Return(nil)
+
+	updates := make(chan *ffcapi.BlockHashEvent)
+	bl.addConsumer(&blockUpdateConsumer{
+		id:      fftypes.NewUUID(),
+		ctx:     context.Background(),
+		updates: updates,
+	})
+
+	bu := <-updates
+	assert.Equal(t, []string{
+		block1002HashA.String(),
+		block1003HashA.String(),
+	}, bu.BlockHashes)
+	bu = <-updates
+	assert.Equal(t, []string{
+		block1002HashB.String(),
+		block1003HashB.String(),
 	}, bu.BlockHashes)
 	assert.False(t, bu.GapPotential)
 
@@ -150,6 +736,8 @@ func TestBlockListenerClosed(t *testing.T) {
 	_, c, mRPC, done := newTestConnector(t)
 	bl := c.blockListener
 	bl.blockPollingInterval = 1 * time.Microsecond
+	block1002Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
 
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*ethtypes.HexInteger)
@@ -162,7 +750,7 @@ func TestBlockListenerClosed(t *testing.T) {
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
 		*hbh = []ethtypes.HexBytes0xPrefix{
-			ethtypes.MustNewHexBytes0xPrefix("0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42"),
+			block1003Hash,
 		}
 	}).Once()
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -172,10 +760,12 @@ func TestBlockListenerClosed(t *testing.T) {
 	})
 
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
-		return bh == "0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42"
+		return bh == block1003Hash.String()
 	}), false).Return(nil).Run(func(args mock.Arguments) {
 		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
-			Number: ethtypes.NewHexInteger64(1003),
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003Hash,
+			ParentHash: block1002Hash,
 		}
 	})
 
@@ -198,6 +788,7 @@ func TestBlockListenerBlockNotFound(t *testing.T) {
 	_, c, mRPC, done := newTestConnector(t)
 	bl := c.blockListener
 	bl.blockPollingInterval = 1 * time.Microsecond
+	block1003Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
 
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*ethtypes.HexInteger)
@@ -210,7 +801,7 @@ func TestBlockListenerBlockNotFound(t *testing.T) {
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
 		*hbh = []ethtypes.HexBytes0xPrefix{
-			ethtypes.MustNewHexBytes0xPrefix("0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42"),
+			block1003Hash,
 		}
 	}).Once()
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -218,7 +809,7 @@ func TestBlockListenerBlockNotFound(t *testing.T) {
 	})
 
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
-		return bh == "0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42"
+		return bh == block1003Hash.String()
 	}), false).Return(nil)
 
 	bl.checkStartedLocked()
@@ -234,6 +825,7 @@ func TestBlockListenerBlockHashFailed(t *testing.T) {
 	_, c, mRPC, done := newTestConnector(t)
 	bl := c.blockListener
 	bl.blockPollingInterval = 1 * time.Microsecond
+	block1003Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
 
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*ethtypes.HexInteger)
@@ -246,7 +838,7 @@ func TestBlockListenerBlockHashFailed(t *testing.T) {
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
 		*hbh = []ethtypes.HexBytes0xPrefix{
-			ethtypes.MustNewHexBytes0xPrefix("0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42"),
+			block1003Hash,
 		}
 	}).Once()
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -254,7 +846,7 @@ func TestBlockListenerBlockHashFailed(t *testing.T) {
 	})
 
 	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
-		return bh == "0xe74ebee74141ef8932666923fae9b8d6cf04ba67989e7908fcddb66565d41e42"
+		return bh == block1003Hash.String()
 	}), false).Return(fmt.Errorf("pop"))
 
 	bl.checkStartedLocked()
@@ -327,4 +919,37 @@ func TestBlockListenerDispatchStopped(t *testing.T) {
 	}, &ffcapi.BlockHashEvent{
 		BlockHashes: []string{},
 	})
+}
+
+func TestBlockListenerRebuildCanonicalChainEmpty(t *testing.T) {
+
+	_, c, _, done := newTestConnector(t)
+	defer done()
+	bl := c.blockListener
+
+	res := bl.rebuildCanonicalChain()
+	assert.Nil(t, res)
+
+}
+
+func TestBlockListenerRebuildCanonicalFailTerminate(t *testing.T) {
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.canonicalChain.PushBack(&minimalBlockInfo{
+		number:     1000,
+		hash:       ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String()).String(),
+		parentHash: ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String()).String(),
+	})
+
+	mRPC.On("Invoke", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.Anything, false).
+		Return(fmt.Errorf("pop")).
+		Run(func(args mock.Arguments) {
+			done()
+		})
+
+	res := bl.rebuildCanonicalChain()
+	assert.Nil(t, res)
+
+	mRPC.AssertExpectations(t)
 }

--- a/internal/ethereum/config.go
+++ b/internal/ethereum/config.go
@@ -41,8 +41,8 @@ const (
 	DefaultListenerPort        = 5102
 	DefaultGasEstimationFactor = 1.5
 
-	DefaultCatchupPageSize          = 5000
-	DefaultEventsCatchupThreshold   = 5000
+	DefaultCatchupPageSize          = 2500
+	DefaultEventsCatchupThreshold   = 2500
 	DefaultEventsCheckpointBlockGap = 50
 
 	DefaultRetryInitDelay   = "100ms"

--- a/internal/jsonrpc/rpc.go
+++ b/internal/jsonrpc/rpc.go
@@ -105,8 +105,8 @@ func (r *jsonRPC) Invoke(ctx context.Context, result interface{}, method string,
 		log.L(ctx).Tracef("RPC:%s:%s OUTPUT: %s", rpcReq.ID, rpcReq.ID, jsonOutput)
 	}
 	// JSON/RPC allows errors to be returned with a 200 status code, as well as other status codes
-	if res.IsError() || rpcRes.Error != nil && rpcRes.Error.Message != "" {
-		log.L(ctx).Errorf("RPC[%d] <-- [%d]: %s", id, res.StatusCode(), rpcRes.Message())
+	if res.IsError() || rpcRes.Error != nil && rpcRes.Error.Code != 0 {
+		log.L(ctx).Errorf("RPC[%d] <-- [%d]: '%s'", id, res.StatusCode(), rpcRes.Message())
 		err := fmt.Errorf(rpcRes.Message())
 		return err
 	}

--- a/internal/jsonrpc/rpc.go
+++ b/internal/jsonrpc/rpc.go
@@ -106,7 +106,7 @@ func (r *jsonRPC) Invoke(ctx context.Context, result interface{}, method string,
 	}
 	// JSON/RPC allows errors to be returned with a 200 status code, as well as other status codes
 	if res.IsError() || rpcRes.Error != nil && rpcRes.Error.Code != 0 {
-		log.L(ctx).Errorf("RPC[%d] <-- [%d]: '%s'", id, res.StatusCode(), rpcRes.Message())
+		log.L(ctx).Errorf("RPC[%d] <-- [%d]: %d '%s'", id, res.StatusCode(), rpcRes.Error.Code, rpcRes.Message())
 		err := fmt.Errorf(rpcRes.Message())
 		return err
 	}


### PR DESCRIPTION
Resolves #9
Resolves #10 
Resolves #12 
Implements https://github.com/hyperledger/firefly-transaction-manager/issues/22

- For #9
    - Set catchup block gap / page size default to 2500
    - Fall back to catchup mode if we are about to call `eth_getFilterLogs` to far back from the chain head
- For #10
    - Enhance block listener to handle gaps in JSON/RPC stream, by holding an in-memory view of canonical chain
- For #12 
    - Treat a negative error code, with an empty `message` in a JSON/RPC response as an error
- For https://github.com/hyperledger/firefly-transaction-manager/issues/22
    - Add `catchup` flag to `getListenerHWM`