### PR TITLE
Handle alternative response text for known transaction errors

### DIFF
--- a/internal/ethereum/error_mapping.go
+++ b/internal/ethereum/error_mapping.go
@@ -59,6 +59,8 @@ func mapError(methodType ethRPCMethodCategory, err error) ffcapi.ErrorReason {
 			return ffcapi.ErrorReasonTransactionUnderpriced
 		case strings.Contains(errString, "known transaction"):
 			return ffcapi.ErrorKnownTransaction
+		case strings.Contains(errString, "already known"):
+			return ffcapi.ErrorKnownTransaction
 		}
 	case blockRPCMethods:
 		// https://docs.avax.network/quickstart/integrate-exchange-with-avalanche#determining-finality


### PR DESCRIPTION
Signed-off-by: Matthew Whitehead <matthew.whitehead@kaleido.io>