### PR TITLE
Remove `0x12345:event()` address prefix from "signature" of emitted events

### DIFF
--- a/internal/ethereum/event_listener.go
+++ b/internal/ethereum/event_listener.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"sync"
 
@@ -323,9 +322,6 @@ func (l *listener) filterEnrichEthLog(ctx context.Context, f *eventFilter, ethLo
 	}
 
 	signature := f.Signature
-	if ethLog.Address != nil {
-		signature = fmt.Sprintf("%s:%s", ethLog.Address, signature)
-	}
 	return &ffcapi.ListenerEvent{
 		Checkpoint: &listenerCheckpoint{
 			Block:            blockNumber,


### PR DESCRIPTION
There is a confusing inconsistency between EVMConnect and EthConnect.
The `signature` field that EVMConnect passes to `FFTM` contains the address prefixed to it.
So you get something like:

`0xfa21c3539986094bbddeb565d6c716e97c1d3c3a:TransferSingle(address,address,address,uint256,uint256)`

Whereas in EthConnect you would have just received:

`TransferSingle(address,address,address,uint256,uint256)`

Given that the address is not part of the signature of the event, it is confusing to have to strip it out.
We did add in the 1.1 development some handling for this inconsistency in the tokens connectors, and FireFly, but that actually adds to the confusion. As Tokens connectors strip the prefix, but others do not.