### PR TITLE
Add support for parsing custom errors

### DIFF
--- a/internal/msgs/en_error_messges.go
+++ b/internal/msgs/en_error_messges.go
@@ -65,4 +65,5 @@ var (
 	MsgTimedOutQueryingChainHead = ffe("FF23046", "Timed out waiting for chain head block number")
 	MsgDecodeBytecodeFailed      = ffe("FF23047", "Failed to decode 'bytecode' as hex or Base64")
 	MsgInvalidTXHashReturned     = ffe("FF23048", "Received invalid transaction hash from node len=%d")
+	MsgUnmarshalErrorFail        = ffe("FF23049", "Failed to parse error %d: %s")
 )


### PR DESCRIPTION
This allows the transaction payload to include an optional `errors` section that specifies the FFI for custom error definitions:

```
{
	"ffcapi": {
		"version": "v1.0.0",
		"id": "904F177C-C790-4B01-BDF4-F2B4E52E607E",
		"type": "exec_query"
	},
	"from": "0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8",
	"to": "0xe1a078b9e2b145d0a7387f09277c6ae1d9470771",
	"nonce": "222",
	"method": {
		"inputs": [
			{
				"internalType":" uint256",
				"name": "x",
				"type": "uint256"
			}
		],
		"name":"set",
		"outputs":[
			{
				"internalType":"uint256",
				"name": "",
				"type": "uint256"
			},
			{
				"type": "string"
			}
		],
		"stateMutability":"nonpayable",
		"type":"function"
	},
	"errors": [
		{
      "inputs": [
        {
          "internalType": "uint256",
          "name": "x",
          "type": "uint256"
        },
        {
          "internalType": "uint256",
          "name": "y",
          "type": "uint256"
        }
      ],
      "name": "GreaterThanTen",
      "type": "error"
    },
    {
      "inputs": [
        {
          "internalType": "uint256",
          "name": "x",
          "type": "uint256"
        }
      ],
      "name": "LessThanOne",
      "type": "error"
    }
	],
	"params": [ 4276993775 ]
}
```

for a solidity contract that declares custom errors like the following:

```
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.0;

error GreaterThanTen(uint256 x, uint256 y);
error LessThanOne(uint256 x);

contract SimpleStorage {
    uint256 storedData;

    function set(uint256 x) public {
        if (x > 10) {
            revert GreaterThanTen({x: x, y: x});
        }
        if (x < 1) {
            revert LessThanOne({x: x});
        }
        storedData = x;
    }
}
```