### PR TITLE
Set protocolId in all transaction receipts

### DIFF
--- a/internal/ethereum/get_receipt.go
+++ b/internal/ethereum/get_receipt.go
@@ -19,6 +19,7 @@ package ethereum
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
@@ -82,6 +83,13 @@ func (c *ethConnector) getTransactionInfo(ctx context.Context, hash ethtypes.Hex
 	return txInfo, err
 }
 
+func ProtocolIDForReceipt(blockNumber, transactionIndex *fftypes.FFBigInt) string {
+	if blockNumber != nil && transactionIndex != nil {
+		return fmt.Sprintf("%.12d/%.6d", blockNumber.Int(), transactionIndex.Int())
+	}
+	return ""
+}
+
 func (c *ethConnector) TransactionReceipt(ctx context.Context, req *ffcapi.TransactionReceiptRequest) (*ffcapi.TransactionReceiptResponse, ffcapi.ErrorReason, error) {
 
 	// Get the receipt in the back-end JSON/RPC format
@@ -114,6 +122,7 @@ func (c *ethConnector) TransactionReceipt(ctx context.Context, req *ffcapi.Trans
 		TransactionIndex: fftypes.NewFFBigInt(txIndex),
 		BlockHash:        ethReceipt.BlockHash.String(),
 		Success:          isSuccess,
+		ProtocolID:       ProtocolIDForReceipt((*fftypes.FFBigInt)(ethReceipt.BlockNumber), fftypes.NewFFBigInt(txIndex)),
 		ExtraInfo:        fftypes.JSONAnyPtrBytes(fullReceipt),
 	}, "", nil
 

--- a/internal/ethereum/get_receipt_test.go
+++ b/internal/ethereum/get_receipt_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-signer/pkg/rpcbackend"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
@@ -133,4 +134,9 @@ func TestGetReceiptError(t *testing.T) {
 	assert.Empty(t, "", reason)
 	assert.Nil(t, res)
 
+}
+
+func TestProtocolIDForReceipt(t *testing.T) {
+	assert.Equal(t, "000000012345/000042", ProtocolIDForReceipt(fftypes.NewFFBigInt(12345), fftypes.NewFFBigInt(42)))
+	assert.Equal(t, "", ProtocolIDForReceipt(nil, nil))
 }


### PR DESCRIPTION
As required by FireFly core PR https://github.com/hyperledger/firefly/pull/1111 this PR brings evmconnect into line with the updated `TransactionReceiptResponse` struct that adds `protocolId` to transaction receipts.

Signed-off-by: Matthew Whitehead <matthew.whitehead@kaleido.io>