### PR TITLE
Disable ARM64 builds (for now)

### DIFF
--- a/.github/workflows/docker_main.yml
+++ b/.github/workflows/docker_main.yml
@@ -43,7 +43,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ghcr.io/${{ github.repository }}:${{ steps.build_tag_generator.outputs.BUILD_TAG }},ghcr.io/${{ github.repository }}:head
           labels: |
             commit=${{ github.sha }}

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -63,7 +63,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ghcr.io/${{ github.repository }}:${{ github.ref_name }},ghcr.io/${{ github.repository }}:head,${{ env.DOCKER_TAGS }}
           labels: |
             commit=${{ github.sha }}


### PR DESCRIPTION
Timing issues in tests on emulated architectures are causing build failures so this is a temporary mitigation to get builds working.