### PR TITLE
Only require the -f parameter on the root command

### DIFF
--- a/cmd/evmconnect.go
+++ b/cmd/evmconnect.go
@@ -51,7 +51,7 @@ var cfgFile string
 var connectorConfig config.Section
 
 func init() {
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "f", "", "config file")
+	rootCmd.Flags().StringVarP(&cfgFile, "config", "f", "", "config file")
 	rootCmd.AddCommand(versionCommand())
 	rootCmd.AddCommand(configCommand())
 	rootCmd.AddCommand(fftmcmd.ClientCommand())


### PR DESCRIPTION
The `version`/`docs`/`client` commands do not need `-f`