### PR TITLE
Fix docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM golang:1.21-buster AS builder
+FROM golang:1.21-alpine3.19 AS builder
+RUN apk add make
 ARG BUILD_VERSION
 ENV BUILD_VERSION=${BUILD_VERSION}
 ADD --chown=1001:0 . /evmconnect


### PR DESCRIPTION
There is an issue with building docker 

`ERROR: failed to solve: golang:1.21-buster: docker.io/library/golang:1.21-buster: not found`

https://github.com/hyperledger/firefly-evmconnect/actions/runs/7922199644/job/21629266487#step:11:156

Fixed it by using 1.21-alpine3.19 as for example for [tezos connector](https://github.com/hyperledger/firefly-tezosconnect/pull/34)