### PR TITLE
Make the use of `debug_traceTransaction` configurable

### DIFF
--- a/config.md
+++ b/config.md
@@ -75,6 +75,7 @@
 |passthroughHeadersEnabled|Enable passing through the set of allowed HTTP request headers|`boolean`|`false`
 |requestTimeout|The maximum amount of time that a request is allowed to remain open|[`time.Duration`](https://pkg.go.dev/time#Duration)|`30s`
 |tlsHandshakeTimeout|The maximum amount of time to wait for a successful TLS handshake|[`time.Duration`](https://pkg.go.dev/time#Duration)|`10s`
+|traceTXForRevertReason|Enable the use of transaction trace functions (e.g. debug_traceTransaction) to obtain transaction revert reasons. This can place a high load on the EVM client.|`boolean`|`false`
 |txCacheSize|Maximum of transactions to hold in the transaction info cache|`int`|`250`
 |url|URL of JSON/RPC endpoint for the Ethereum node/gateway|string|`<nil>`
 

--- a/internal/ethereum/config.go
+++ b/internal/ethereum/config.go
@@ -37,6 +37,7 @@ const (
 	RetryFactor                 = "retry.factor"
 	MaxConcurrentRequests       = "maxConcurrentRequests"
 	TxCacheSize                 = "txCacheSize"
+	TraceTXForRevertReason      = "traceTXForRevertReason"
 )
 
 const (
@@ -70,4 +71,5 @@ func InitConfig(conf config.Section) {
 	conf.AddKnownKey(RetryMaxDelay, DefaultRetryMaxDelay)
 	conf.AddKnownKey(MaxConcurrentRequests, 50)
 	conf.AddKnownKey(TxCacheSize, 250)
+	conf.AddKnownKey(TraceTXForRevertReason, false)
 }

--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -49,6 +49,7 @@ type ethConnector struct {
 	eventBlockTimestamps       bool
 	blockListener              *blockListener
 	eventFilterPollingInterval time.Duration
+	traceTXForRevertReason     bool
 
 	mux          sync.Mutex
 	eventStreams map[fftypes.UUID]*eventStream
@@ -64,6 +65,7 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc ffcapi.A
 		checkpointBlockGap:         conf.GetInt64(EventsCheckpointBlockGap),
 		eventBlockTimestamps:       conf.GetBool(EventsBlockTimestamps),
 		eventFilterPollingInterval: conf.GetDuration(EventsFilterPollingInterval),
+		traceTXForRevertReason:     conf.GetBool(TraceTXForRevertReason),
 		retry: &retry.Retry{
 			InitialDelay: conf.GetDuration(RetryInitDelay),
 			MaximumDelay: conf.GetDuration(RetryMaxDelay),

--- a/internal/ethereum/ethereum_test.go
+++ b/internal/ethereum/ethereum_test.go
@@ -37,6 +37,7 @@ func newTestConnector(t *testing.T) (context.Context, *ethConnector, *rpcbackend
 	config.RootConfigReset()
 	conf := config.RootSection("unittest")
 	InitConfig(conf)
+	//conf.Set(TraceTXForRevertReason, true)
 	conf.Set(ffresty.HTTPConfigURL, "http://localhost:8545")
 	conf.Set(BlockPollingInterval, "1h") // Disable for tests that are not using it
 	logrus.SetLevel(logrus.DebugLevel)

--- a/internal/ethereum/get_receipt_test.go
+++ b/internal/ethereum/get_receipt_test.go
@@ -102,24 +102,6 @@ const sampleJSONRPCReceiptFailedWithRevertReason = `{
 	"type": "0x0"
 }`
 
-const sampleJSONRPCReceiptFailedWithCustomRevertReason = `{
-	"blockHash": "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6",
-	"blockNumber": "0x7b9",
-	"contractAddress": "0x87ae94ab290932c4e6269648bb47c86978af4436",
-	"cumulativeGasUsed": "0x8414",
-	"effectiveGasPrice": "0x0",
-	"from": "0x2b1c769ef5ad304a4889f2a07a6617cd935849ae",
-	"gasUsed": "0x8414",
-	"logs": [],
-	"logsBloom": "0x00000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000100000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000",
-	"status": "0",
-	"to": "0x302259069aaa5b10dc6f29a9a3f72a8e52837cc3",
-	"transactionHash": "0x7d48ae971faf089878b57e3c28e3035540d34f38af395958d2c73c36c57c83a2",
-	"transactionIndex": "0x1e",
-	"revertReason": "0x1320fa6a00000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000010",
-	"type": "0x0"
-}`
-
 const sampleTransactionTraceGeth = `{
 	"gas": 23512,
 	"failed": true,
@@ -210,7 +192,7 @@ const sampleTransactionTraceBesu = `{
 				"0000000000000000000000000000000000000000000000000000000000000000"
 			],
 			"storage": {},
-			"reason": "0x1320fa6a00000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000010"
+			"reason": "8c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000114e6f7420656e6f75676820746f6b656e73000000000000000000000000000000"
 		}
 	]
 }`
@@ -287,6 +269,7 @@ func TestGetReceiptError(t *testing.T) {
 func TestGetReceiptErrorReasonGeth(t *testing.T) {
 
 	ctx, c, mRPC, done := newTestConnector(t)
+	c.traceTXForRevertReason = true
 	defer done()
 
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt",
@@ -324,6 +307,7 @@ func TestGetReceiptErrorReasonGeth(t *testing.T) {
 func TestGetReceiptErrorReasonBesu(t *testing.T) {
 
 	ctx, c, mRPC, done := newTestConnector(t)
+	c.traceTXForRevertReason = true
 	defer done()
 
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt",
@@ -361,6 +345,7 @@ func TestGetReceiptErrorReasonBesu(t *testing.T) {
 func TestGetReceiptErrorReasonNotFound(t *testing.T) {
 
 	ctx, c, mRPC, done := newTestConnector(t)
+	c.traceTXForRevertReason = true
 	defer done()
 
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt",
@@ -397,6 +382,7 @@ func TestGetReceiptErrorReasonNotFound(t *testing.T) {
 func TestGetReceiptErrorReasonErrorFromHexDecode(t *testing.T) {
 
 	ctx, c, mRPC, done := newTestConnector(t)
+	c.traceTXForRevertReason = true
 	defer done()
 
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt",
@@ -433,6 +419,7 @@ func TestGetReceiptErrorReasonErrorFromTrace(t *testing.T) {
 	// if we get an error tracing the transaction, we ignore it.  Not all nodes support the debug_traceTransaction RPC call
 
 	ctx, c, mRPC, done := newTestConnector(t)
+	c.traceTXForRevertReason = true
 	defer done()
 
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt",
@@ -468,6 +455,7 @@ func TestGetReceiptErrorReasonErrorFromTrace(t *testing.T) {
 func TestGetReceiptErrorReasonErrorFromDecodeCallData(t *testing.T) {
 
 	ctx, c, mRPC, done := newTestConnector(t)
+	c.traceTXForRevertReason = true
 	defer done()
 
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt",
@@ -526,7 +514,7 @@ func TestGetReceiptErrorReasonErrorFromReceiptRevert(t *testing.T) {
 	assert.False(t, res.Success)
 }
 
-func TestGetReceiptErrorReasonCustomErrorFromReceiptRevert(t *testing.T) {
+func TestGetReceiptNoDebugTraceIfDisabled(t *testing.T) {
 
 	ctx, c, mRPC, done := newTestConnector(t)
 	defer done()
@@ -538,18 +526,18 @@ func TestGetReceiptErrorReasonCustomErrorFromReceiptRevert(t *testing.T) {
 		})).
 		Return(nil).
 		Run(func(args mock.Arguments) {
-			err := json.Unmarshal([]byte(sampleJSONRPCReceiptFailedWithCustomRevertReason), args[1])
+			err := json.Unmarshal([]byte(sampleJSONRPCReceiptFailed), args[1])
 			assert.NoError(t, err)
 		})
-	mRPC.AssertNotCalled(t, "CallRPC", mock.Anything, mock.Anything, "debug_traceTransaction", mock.Anything)
+	mRPC.AssertNotCalled(t, "CallRPC", mock.Anything, mock.Anything, "debug_traceTransaction")
 	var req ffcapi.TransactionReceiptRequest
 	err := json.Unmarshal([]byte(sampleGetReceipt), &req)
 	assert.NoError(t, err)
 	res, reason, err := c.TransactionReceipt(ctx, &req)
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
-	assert.Contains(t, res.ExtraInfo.String(), "FF23053: Error return value for custom error: 0x1320fa6a00000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000010") // Check that a custom error which can't be decoded is at least included as a byte string
 	assert.False(t, res.Success)
+	mRPC.AssertExpectations(t)
 }
 
 func TestProtocolIDForReceipt(t *testing.T) {

--- a/internal/ethereum/get_receipt_test.go
+++ b/internal/ethereum/get_receipt_test.go
@@ -102,6 +102,24 @@ const sampleJSONRPCReceiptFailedWithRevertReason = `{
 	"type": "0x0"
 }`
 
+const sampleJSONRPCReceiptFailedWithCustomRevertReason = `{
+	"blockHash": "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6",
+	"blockNumber": "0x7b9",
+	"contractAddress": "0x87ae94ab290932c4e6269648bb47c86978af4436",
+	"cumulativeGasUsed": "0x8414",
+	"effectiveGasPrice": "0x0",
+	"from": "0x2b1c769ef5ad304a4889f2a07a6617cd935849ae",
+	"gasUsed": "0x8414",
+	"logs": [],
+	"logsBloom": "0x00000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000100000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000800000000000000",
+	"status": "0",
+	"to": "0x302259069aaa5b10dc6f29a9a3f72a8e52837cc3",
+	"transactionHash": "0x7d48ae971faf089878b57e3c28e3035540d34f38af395958d2c73c36c57c83a2",
+	"transactionIndex": "0x1e",
+	"revertReason": "0x1320fa6a00000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000010",
+	"type": "0x0"
+}`
+
 const sampleTransactionTraceGeth = `{
 	"gas": 23512,
 	"failed": true,
@@ -192,7 +210,7 @@ const sampleTransactionTraceBesu = `{
 				"0000000000000000000000000000000000000000000000000000000000000000"
 			],
 			"storage": {},
-			"reason": "8c379a0000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000114e6f7420656e6f75676820746f6b656e73000000000000000000000000000000"
+			"reason": "0x1320fa6a00000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000010"
 		}
 	]
 }`
@@ -505,6 +523,32 @@ func TestGetReceiptErrorReasonErrorFromReceiptRevert(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
 	assert.Contains(t, res.ExtraInfo.String(), "The stored value is too small") // Check the decoded revert reason string is present in extra-info
+	assert.False(t, res.Success)
+}
+
+func TestGetReceiptErrorReasonCustomErrorFromReceiptRevert(t *testing.T) {
+
+	ctx, c, mRPC, done := newTestConnector(t)
+	defer done()
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt",
+		mock.MatchedBy(func(txHash string) bool {
+			assert.Equal(t, "0x7d48ae971faf089878b57e3c28e3035540d34f38af395958d2c73c36c57c83a2", txHash)
+			return true
+		})).
+		Return(nil).
+		Run(func(args mock.Arguments) {
+			err := json.Unmarshal([]byte(sampleJSONRPCReceiptFailedWithCustomRevertReason), args[1])
+			assert.NoError(t, err)
+		})
+	mRPC.AssertNotCalled(t, "CallRPC", mock.Anything, mock.Anything, "debug_traceTransaction", mock.Anything)
+	var req ffcapi.TransactionReceiptRequest
+	err := json.Unmarshal([]byte(sampleGetReceipt), &req)
+	assert.NoError(t, err)
+	res, reason, err := c.TransactionReceipt(ctx, &req)
+	assert.NoError(t, err)
+	assert.Empty(t, reason)
+	assert.Contains(t, res.ExtraInfo.String(), "FF23053: Error return value for custom error: 0x1320fa6a00000000000000000000000000000000000000000000000000000000000000640000000000000000000000000000000000000000000000000000000000000010") // Check that a custom error which can't be decoded is at least included as a byte string
 	assert.False(t, res.Success)
 }
 

--- a/internal/msgs/en_config_descriptions.go
+++ b/internal/msgs/en_config_descriptions.go
@@ -40,4 +40,5 @@ var (
 	ConfigEventsFilterPollingInterval = ffc("config.connector.events.filterPollingInterval", "The interval between polling calls to a filter, when checking for newly arrived events", i18n.TimeDurationType)
 	ConfigTxCacheSize                 = ffc("config.connector.txCacheSize", "Maximum of transactions to hold in the transaction info cache", i18n.IntType)
 	ConfigMaxConcurrentRequests       = ffc("config.connector.maxConcurrentRequests", "Maximum of concurrent requests to be submitted to the blockchain", i18n.IntType)
+	ConfigTraceTXForRevertReason      = ffc("config.connector.traceTXForRevertReason", "Enable the use of transaction trace functions (e.g. debug_traceTransaction) to obtain transaction revert reasons. This can place a high load on the EVM client.", i18n.BooleanType)
 )


### PR DESCRIPTION
The `debug_traceTransaction` call is expensive and can potentially make an EVM node unstable, so it's use should be configurable and it should default to `off`.

See https://github.com/hyperledger/firefly/issues/1492