### PR TITLE
use websocket backend for all rpc calls when it's turned on

### DIFF
--- a/internal/ethereum/blocklistener.go
+++ b/internal/ethereum/blocklistener.go
@@ -84,7 +84,6 @@ func newBlockListener(ctx context.Context, c *ethConnector, conf config.Section,
 	}
 	if wsConf != nil {
 		bl.wsBackend = rpcbackend.NewWSRPCClient(wsConf)
-		bl.backend = bl.wsBackend
 	}
 	bl.blockCache, err = lru.New(conf.GetInt(BlockCacheSize))
 	if err != nil {
@@ -118,6 +117,7 @@ func (bl *blockListener) establishBlockHeightWithRetry() error {
 					log.L(bl.ctx).Warnf("WebSocket connection failed, blocking startup of block listener: %s", err)
 					return true, err
 				}
+				bl.backend = bl.wsBackend
 				// if we retry subscribe, we don't want to retry connect
 				wsConnected = true
 			}

--- a/internal/ethereum/blocklistener.go
+++ b/internal/ethereum/blocklistener.go
@@ -84,6 +84,7 @@ func newBlockListener(ctx context.Context, c *ethConnector, conf config.Section,
 	}
 	if wsConf != nil {
 		bl.wsBackend = rpcbackend.NewWSRPCClient(wsConf)
+		bl.backend = bl.wsBackend
 	}
 	bl.blockCache, err = lru.New(conf.GetInt(BlockCacheSize))
 	if err != nil {


### PR DESCRIPTION
When Websocket is turned on, the code currently only use it for receiving new heads. This PR updated the code to use Websockets for all RPC calls as well so a separate HTTP endpoint is not necessary.