### PR TITLE
Decode numbers using json.Decoder

### DIFF
--- a/internal/ethereum/deploy_contract_prepare.go
+++ b/internal/ethereum/deploy_contract_prepare.go
@@ -17,6 +17,7 @@
 package ethereum
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/hex"
@@ -95,7 +96,9 @@ func (c *ethConnector) prepareDeployData(ctx context.Context, req *ffcapi.Contra
 	ethParams := make([]interface{}, len(req.Params))
 	for i, p := range req.Params {
 		if p != nil {
-			err := json.Unmarshal([]byte(*p), &ethParams[i])
+			decodedParam := json.NewDecoder(bytes.NewReader([]byte(*p)))
+			decodedParam.UseNumber()
+			err := decodedParam.Decode(&ethParams[i])
 			if err != nil {
 				return nil, nil, i18n.NewError(ctx, msgs.MsgUnmarshalParamFail, i, err)
 			}

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -47,17 +47,12 @@ const samplePrepareDeployTX = `{
 				"internalType":" uint256",
 				"name": "y",
 				"type": "uint256"
-			},
-		    {
-			    "internalType":" string",
-			    "name": "x",
-			    "type": "string"
-		    }
+			}
 		],
 		"outputs":[],
 		"type":"constructor"
 	}],
-	"params": [ 4276993775, "some-text" ]
+	"params": [ 4276993775 ]
 }`
 
 const samplePrepareDeployTXLargeInputParams = `{
@@ -104,10 +99,8 @@ func TestDeployContractPrepareOkNoEstimate(t *testing.T) {
 	assert.Empty(t, reason)
 	assert.Equal(t, int64(1000000), res.Gas.Int64())
 
-	// Basic check that our input param 10000000000000000000000001 is in the TX data
+	// Basic check that our input param 4276993775 is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "feedbeef"))
-	// Basic check that our input param "some-text" is in the TX data
-	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))
 }
 
 func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
@@ -122,7 +115,7 @@ func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
 	assert.Equal(t, int64(1000000), res.Gas.Int64())
-	// Basic check that our input param 4276993775 is in the TX data
+	// Basic check that our input param 10000000000000000000000001 is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
 	// Basic check that our input param "some-text" is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -18,7 +18,6 @@ package ethereum
 
 import (
 	"encoding/json"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -41,19 +40,24 @@ const samplePrepareDeployTX = `{
 	"gas": 1000000,
 	"nonce": "111",
 	"value": "12345678901234567890123456789",
-	"contract": "0xfeedbeef",
+	"contract": "0xdeadbeef",
 	"definition": [{
 		"inputs": [
 			{
 				"internalType":" uint256",
-				"name": "x",
+				"name": "y",
 				"type": "uint256"
-			}
+			},
+		    {
+			    "internalType":" string",
+			    "name": "x",
+			    "type": "string"
+		    }
 		],
 		"outputs":[],
 		"type":"constructor"
 	}],
-	"params": [ 4276993775 ]
+	"params": [ 4276993775, "some-text" ]
 }`
 
 const samplePrepareDeployTXLargeInputParams = `{
@@ -67,19 +71,24 @@ const samplePrepareDeployTXLargeInputParams = `{
 	"gas": 1000000,
 	"nonce": "111",
 	"value": "12345678901234567890123456789",
-	"contract": "0xfeedbeef",
+	"contract": "0xdeadbeef",
 	"definition": [{
 		"inputs": [
 			{
 				"internalType":" uint256",
-				"name": "x",
+				"name": "y",
 				"type": "uint256"
-			}
+			},
+		    {
+			    "internalType":" string",
+			    "name": "x",
+			    "type": "string"
+		    }
 		],
 		"outputs":[],
 		"type":"constructor"
 	}],
-	"params": [ 10000000000000000000000001 ]
+	"params": [ 10000000000000000000000001, "some-text" ]
 }`
 
 func TestDeployContractPrepareOkNoEstimate(t *testing.T) {
@@ -94,7 +103,11 @@ func TestDeployContractPrepareOkNoEstimate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
 	assert.Equal(t, int64(1000000), res.Gas.Int64())
-	assert.True(t, strings.HasSuffix(res.TransactionData, "feedbeef"))
+
+	// Basic check that our input param 10000000000000000000000001 is in the TX data
+	assert.True(t, strings.Contains(res.TransactionData, "feedbeef"))
+	// Basic check that our input param "some-text" is in the TX data
+	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))
 }
 
 func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
@@ -109,8 +122,10 @@ func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
 	assert.Equal(t, int64(1000000), res.Gas.Int64())
-	fmt.Println(res.TransactionData)
-	assert.True(t, strings.HasSuffix(res.TransactionData, "84595161401484a000001"))
+	// Basic check that our input param 4276993775 is in the TX data
+	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
+	// Basic check that our input param "some-text" is in the TX data
+	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))
 }
 
 func TestDeployContractPrepareWithEstimateRevert(t *testing.T) {

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -18,6 +18,7 @@ package ethereum
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -108,7 +109,8 @@ func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
 	assert.Equal(t, int64(1000000), res.Gas.Int64())
-	assert.True(t, strings.HasSuffix(res.TransactionData, "84595161401484A000001"))
+	fmt.Println(res.TransactionData)
+	assert.True(t, strings.HasSuffix(res.TransactionData, "84595161401484a000001"))
 }
 
 func TestDeployContractPrepareWithEstimateRevert(t *testing.T) {


### PR DESCRIPTION
If the `params` passed in for a contract deploy include very large numbers, `json.Unmarshal` to an `interface{}` doesn't work and results in an incorrect number being passed in to the contract's constructor.

To recreate the issue, if you checkout just the UT changes from this branch and run them it will fail.

This PR switches `json.Unmarshal` to `json.Decode`.

