### PR TITLE
Add support for large numbers, and exploit new support in `firefly-signer` for scientific notation numbers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,3 +100,5 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/hyperledger/firefly-signer => github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hyperledger/firefly-common v1.4.8 h1:0o1Qp1c5YzQo8nbnX+gAo9SVd2tR4Z9U2t8Y4zEzyaA=
 github.com/hyperledger/firefly-common v1.4.8/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
-github.com/hyperledger/firefly-signer v1.1.13 h1:eiHjc6HPRG8AzXUCUgm51qqX1I9BokiuiiqJ89XwK4M=
-github.com/hyperledger/firefly-signer v1.1.13/go.mod h1:pK6kivzBFSue3zpJSQpH67VasnLLbwBJOBUNv0zHbRA=
 github.com/hyperledger/firefly-transaction-manager v1.3.15 h1:IyWIId+uytqjIRMxROk5OqOcdHMzJFGFKpQQybiISOU=
 github.com/hyperledger/firefly-transaction-manager v1.3.15/go.mod h1:N3BoHh8+dWG710oQKuNiXmJNEOBBeLTsQ8GpZ41vhog=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -117,6 +115,8 @@ github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bww
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256 h1:uu4qVM451mnU+mOH8TUvPfynnvxEbWzaiISl1MSIDSM=
+github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256/go.mod h1:pK6kivzBFSue3zpJSQpH67VasnLLbwBJOBUNv0zHbRA=
 github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/internal/ethereum/deploy_contract_prepare.go
+++ b/internal/ethereum/deploy_contract_prepare.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-evmconnect/internal/msgs"
@@ -92,7 +93,7 @@ func (c *ethConnector) prepareDeployData(ctx context.Context, req *ffcapi.Contra
 	}
 
 	// Parse the params into the standard semantics of Go JSON unmarshalling, with []interface{}
-	ethParams := make([]interface{}, len(req.Params))
+	ethParams := make([]fftypes.JSONAny, len(req.Params))
 	for i, p := range req.Params {
 		if p != nil {
 			err := json.Unmarshal([]byte(*p), &ethParams[i])

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -168,7 +168,6 @@ func TestDeployContractPrepareOkScientificNotationParam(t *testing.T) {
 	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
 	// Basic check that our input param "some-text" is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))
-	assert.Error(t, err)
 }
 
 func TestDeployContractPrepareWithEstimateRevert(t *testing.T) {


### PR DESCRIPTION
`firefly-signer` PR https://github.com/hyperledger/firefly-evmconnect/pull/150 adds support for parsing scientific notation numbers using `big.ParseFloat()`. This PR pulls in the new version of `firefly-signer`, and changes the type that input params are unmarshalled to, from `interface{}` to `fftpyes.JSONAny`. The latter ensures that large numbers (e.g. `10000000000000000000` aren't converted to `float64` and hence lose data.