### PR TITLE
Exploit new support in `firefly-signer` and `firefly-common` for large & scientific JSON numbers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,3 +100,5 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/hyperledger/firefly-signer => github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256

--- a/go.mod
+++ b/go.mod
@@ -101,4 +101,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/hyperledger/firefly-signer => github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256
+replace github.com/hyperledger/firefly-signer => github.com/kaleido-io/firefly-signer v0.0.0-20240827135812-3c6f71cfc108
+
+replace github.com/hyperledger/firefly-common => github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
-replace github.com/hyperledger/firefly-signer => github.com/kaleido-io/firefly-signer v0.0.0-20240827135812-3c6f71cfc108
+replace github.com/hyperledger/firefly-signer => github.com/kaleido-io/firefly-signer v0.0.0-20240827145609-70863b71eb78
 
 replace github.com/hyperledger/firefly-common => github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ toolchain go1.21.6
 
 require (
 	github.com/hashicorp/golang-lru v1.0.2
-	github.com/hyperledger/firefly-common v1.4.8
-	github.com/hyperledger/firefly-signer v1.1.13
-	github.com/hyperledger/firefly-transaction-manager v1.3.15
+	github.com/hyperledger/firefly-common v1.4.9
+	github.com/hyperledger/firefly-signer v1.1.14
+	github.com/hyperledger/firefly-transaction-manager v1.3.16
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.8.4
@@ -100,7 +100,3 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/hyperledger/firefly-signer => github.com/kaleido-io/firefly-signer v0.0.0-20240827145609-70863b71eb78
-
-replace github.com/hyperledger/firefly-common => github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,6 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/hyperledger/firefly-common v1.4.8 h1:0o1Qp1c5YzQo8nbnX+gAo9SVd2tR4Z9U2t8Y4zEzyaA=
-github.com/hyperledger/firefly-common v1.4.8/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
 github.com/hyperledger/firefly-transaction-manager v1.3.15 h1:IyWIId+uytqjIRMxROk5OqOcdHMzJFGFKpQQybiISOU=
 github.com/hyperledger/firefly-transaction-manager v1.3.15/go.mod h1:N3BoHh8+dWG710oQKuNiXmJNEOBBeLTsQ8GpZ41vhog=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -115,8 +113,10 @@ github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bww
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256 h1:uu4qVM451mnU+mOH8TUvPfynnvxEbWzaiISl1MSIDSM=
-github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256/go.mod h1:pK6kivzBFSue3zpJSQpH67VasnLLbwBJOBUNv0zHbRA=
+github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156 h1:HQpScPoAm9xsACbu9r31wVQ5sQFxLsfe9XzPGY5c4rI=
+github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
+github.com/kaleido-io/firefly-signer v0.0.0-20240827135812-3c6f71cfc108 h1:Vix70J+rkeInHxhl3evmLij4QhE33zo6GCgaB2ZLp8c=
+github.com/kaleido-io/firefly-signer v0.0.0-20240827135812-3c6f71cfc108/go.mod h1:Xj2PF6y8Ce26jX38ch0KasNnnZCSyzcwyLSv8NN+7JA=
 github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/go.sum
+++ b/go.sum
@@ -102,8 +102,6 @@ github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/hyperledger/firefly-common v1.4.8 h1:0o1Qp1c5YzQo8nbnX+gAo9SVd2tR4Z9U2t8Y4zEzyaA=
 github.com/hyperledger/firefly-common v1.4.8/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
-github.com/hyperledger/firefly-signer v1.1.13 h1:eiHjc6HPRG8AzXUCUgm51qqX1I9BokiuiiqJ89XwK4M=
-github.com/hyperledger/firefly-signer v1.1.13/go.mod h1:pK6kivzBFSue3zpJSQpH67VasnLLbwBJOBUNv0zHbRA=
 github.com/hyperledger/firefly-transaction-manager v1.3.15 h1:IyWIId+uytqjIRMxROk5OqOcdHMzJFGFKpQQybiISOU=
 github.com/hyperledger/firefly-transaction-manager v1.3.15/go.mod h1:N3BoHh8+dWG710oQKuNiXmJNEOBBeLTsQ8GpZ41vhog=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
@@ -117,6 +115,8 @@ github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bww
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
+github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256 h1:uu4qVM451mnU+mOH8TUvPfynnvxEbWzaiISl1MSIDSM=
+github.com/kaleido-io/firefly-signer v0.0.0-20240823134028-a2c5b23d5256/go.mod h1:pK6kivzBFSue3zpJSQpH67VasnLLbwBJOBUNv0zHbRA=
 github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156 h1:HQpScPoAm9xsACbu9r31wVQ5sQFxLsfe9XzPGY5c4rI=
 github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
-github.com/kaleido-io/firefly-signer v0.0.0-20240827135812-3c6f71cfc108 h1:Vix70J+rkeInHxhl3evmLij4QhE33zo6GCgaB2ZLp8c=
-github.com/kaleido-io/firefly-signer v0.0.0-20240827135812-3c6f71cfc108/go.mod h1:Xj2PF6y8Ce26jX38ch0KasNnnZCSyzcwyLSv8NN+7JA=
+github.com/kaleido-io/firefly-signer v0.0.0-20240827145609-70863b71eb78 h1:KVn6azO0KM9NH6+SYktI3Lh8AyQXutYdMb45lZXO+Uc=
+github.com/kaleido-io/firefly-signer v0.0.0-20240827145609-70863b71eb78/go.mod h1:Xj2PF6y8Ce26jX38ch0KasNnnZCSyzcwyLSv8NN+7JA=
 github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,12 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/huandu/xstrings v1.3.3/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/huandu/xstrings v1.4.0 h1:D17IlohoQq4UcpqD7fDk80P7l+lwAmlFaBHgOipl2FU=
 github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
-github.com/hyperledger/firefly-transaction-manager v1.3.15 h1:IyWIId+uytqjIRMxROk5OqOcdHMzJFGFKpQQybiISOU=
-github.com/hyperledger/firefly-transaction-manager v1.3.15/go.mod h1:N3BoHh8+dWG710oQKuNiXmJNEOBBeLTsQ8GpZ41vhog=
+github.com/hyperledger/firefly-common v1.4.9 h1:PfPZ73FN8WUoPl8iF8ud00B8476+jmqXHHi94w0Krbc=
+github.com/hyperledger/firefly-common v1.4.9/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
+github.com/hyperledger/firefly-signer v1.1.14 h1:gSGwdBHTLPchGlmLOKk2Y2nawfMhlH2CDm2owt0lIUE=
+github.com/hyperledger/firefly-signer v1.1.14/go.mod h1:Xj2PF6y8Ce26jX38ch0KasNnnZCSyzcwyLSv8NN+7JA=
+github.com/hyperledger/firefly-transaction-manager v1.3.16 h1:rW6rptO4LcOeUYVOMTyvsfPcOzNLBpmBTj4T6n0/vpY=
+github.com/hyperledger/firefly-transaction-manager v1.3.16/go.mod h1:UT4Cijjsz5AqiXa9H3GUiT2vm2Hq1wEgT0n/shsYZp0=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
@@ -113,10 +117,6 @@ github.com/jarcoal/httpmock v1.2.0 h1:gSvTxxFR/MEMfsGrvRbdfpRUMBStovlSRLw0Ep1bww
 github.com/jarcoal/httpmock v1.2.0/go.mod h1:oCoTsnAz4+UoOUIf5lJOWV2QQIW5UoeUI6aM2YnWAZk=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
-github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156 h1:HQpScPoAm9xsACbu9r31wVQ5sQFxLsfe9XzPGY5c4rI=
-github.com/kaleido-io/firefly-common v0.0.0-20240827134901-edb07289f156/go.mod h1:dXewcVMFNON2SvQ1UPvu64OWUt77+M3p8qy61lT1kE4=
-github.com/kaleido-io/firefly-signer v0.0.0-20240827145609-70863b71eb78 h1:KVn6azO0KM9NH6+SYktI3Lh8AyQXutYdMb45lZXO+Uc=
-github.com/kaleido-io/firefly-signer v0.0.0-20240827145609-70863b71eb78/go.mod h1:Xj2PF6y8Ce26jX38ch0KasNnnZCSyzcwyLSv8NN+7JA=
 github.com/karlseguin/ccache v2.0.3+incompatible h1:j68C9tWOROiOLWTS/kCGg9IcJG+ACqn5+0+t8Oh83UU=
 github.com/karlseguin/ccache v2.0.3+incompatible/go.mod h1:CM9tNPzT6EdRh14+jiW8mEF9mkNZuuE51qmgGYUB93w=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=

--- a/internal/ethereum/deploy_contract_prepare.go
+++ b/internal/ethereum/deploy_contract_prepare.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-evmconnect/internal/msgs"
@@ -93,10 +92,10 @@ func (c *ethConnector) prepareDeployData(ctx context.Context, req *ffcapi.Contra
 	}
 
 	// Parse the params into the standard semantics of Go JSON unmarshalling, with []interface{}
-	ethParams := make([]fftypes.JSONAny, len(req.Params))
+	ethParams := make([]interface{}, len(req.Params))
 	for i, p := range req.Params {
 		if p != nil {
-			err := json.Unmarshal([]byte(*p), &ethParams[i])
+			err := p.Unmarshal(ctx, &ethParams[i])
 			if err != nil {
 				return nil, nil, i18n.NewError(ctx, msgs.MsgUnmarshalParamFail, i, err)
 			}

--- a/internal/ethereum/deploy_contract_prepare.go
+++ b/internal/ethereum/deploy_contract_prepare.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
 	"github.com/hyperledger/firefly-evmconnect/internal/msgs"
@@ -92,7 +93,7 @@ func (c *ethConnector) prepareDeployData(ctx context.Context, req *ffcapi.Contra
 	}
 
 	// Parse the params into the standard semantics of Go JSON unmarshalling, with []interface{}
-	ethParams := make([]interface{}, len(req.Params))
+	ethParams := make([]fftypes.JSONAny, len(req.Params))
 	for i, p := range req.Params {
 		if p != nil {
 			err := json.Unmarshal([]byte(*p), &ethParams[i])

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -45,14 +45,24 @@ const samplePrepareDeployTX = `{
 		"inputs": [
 			{
 				"internalType":" uint256",
-				"name": "y",
+				"name": "x",
 				"type": "uint256"
-			}
+			},
+		    {
+			    "internalType":" address",
+			    "name": "y",
+			    "type": "address"
+		    },
+		    {
+			    "internalType":" string",
+			    "name": "z",
+			    "type": "string"
+		    }
 		],
 		"outputs":[],
 		"type":"constructor"
 	}],
-	"params": [ 4276993775 ]
+	"params": [ 4276993775, "0x5f906824E562B6a0F278D910D388728b833a43bB", "some-text" ]
 }`
 
 const samplePrepareDeployTXLargeInputParams = `{
@@ -132,6 +142,10 @@ func TestDeployContractPrepareOkNoEstimate(t *testing.T) {
 
 	// Basic check that our input param 4276993775 is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "feedbeef"))
+	// Basic check that our input param "some-text" is in the TX data
+	assert.True(t, strings.Contains(res.TransactionData, strings.ToLower("736f6d652d74657874")))
+	// Basic check that our input param address is in the TX data
+	assert.True(t, strings.Contains(res.TransactionData, strings.ToLower("5f906824E562B6a0F278D910D388728b833a43bB")))
 }
 
 func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
@@ -146,6 +160,7 @@ func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, reason)
 	assert.Equal(t, int64(1000000), res.Gas.Int64())
+
 	// Basic check that our input param 10000000000000000000000001 is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
 	// Basic check that our input param "some-text" is in the TX data

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -323,7 +323,7 @@ func TestDeployContractPrepareBadParamType(t *testing.T) {
 
 	var req ffcapi.ContractDeployPrepareRequest
 	err := json.Unmarshal([]byte(samplePrepareDeployTX), &req)
-	req.Params = []*fftypes.JSONAny{fftypes.JSONAnyPtr(`"!wrong"`)}
+	req.Params = []*fftypes.JSONAny{fftypes.JSONAnyPtr(`"!wrong"`), fftypes.JSONAnyPtr(`"0x90eB678C3586103805a676d21721Cc6883a6c3AE"`), fftypes.JSONAnyPtr(`"helloworld"`)}
 	assert.NoError(t, err)
 	_, reason, err := c.DeployContractPrepare(ctx, &req)
 

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -168,7 +168,6 @@ func TestDeployContractPrepareOkScientificNotationParam(t *testing.T) {
 	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
 	// Basic check that our input param "some-text" is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))
-	assert.Error(t, err)
 }
 
 func TestDeployContractPrepareWithEstimateRevert(t *testing.T) {

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -96,6 +96,37 @@ const samplePrepareDeployTXLargeInputParams = `{
 	"params": [ 10000000000000000000000001, "some-text" ]
 }`
 
+const samplePrepareDeployTXScientificNotation = `{
+	"ffcapi": {
+		"version": "v1.0.0",
+		"id": "904F177C-C790-4B01-BDF4-F2B4E52E607E",
+		"type": "DeployContract"
+	},
+	"from": "0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8",
+	"to": "0xe1a078b9e2b145d0a7387f09277c6ae1d9470771",
+	"gas": 1000000,
+	"nonce": "111",
+	"value": "12345678901234567890123456789",
+	"contract": "0xdeadbeef",
+	"definition": [{
+		"inputs": [
+			{
+				"internalType":" uint256",
+				"name": "x",
+				"type": "uint256"
+			},
+		    {
+			    "internalType":" string",
+			    "name": "y",
+			    "type": "string"
+		    }
+		],
+		"outputs":[],
+		"type":"constructor"
+	}],
+	"params": [ 1.0000000000000000000000001e+25, "some-text" ]
+}`
+
 func TestDeployContractPrepareOkNoEstimate(t *testing.T) {
 
 	ctx, c, _, done := newTestConnector(t)
@@ -131,6 +162,24 @@ func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
 	assert.Equal(t, int64(1000000), res.Gas.Int64())
 
 	// Basic check that our input param 10000000000000000000000001 is in the TX data
+	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
+	// Basic check that our input param "some-text" is in the TX data
+	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))
+}
+
+func TestDeployContractPrepareOkScientificNotationParam(t *testing.T) {
+
+	ctx, c, _, done := newTestConnector(t)
+	defer done()
+
+	var req ffcapi.ContractDeployPrepareRequest
+	err := json.Unmarshal([]byte(samplePrepareDeployTXScientificNotation), &req)
+	assert.NoError(t, err)
+	res, reason, err := c.DeployContractPrepare(ctx, &req)
+	assert.NoError(t, err)
+	assert.Empty(t, reason)
+	assert.Equal(t, int64(1000000), res.Gas.Int64())
+	// Basic check that our input param 1.0000000000000000000000001e+25 is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
 	// Basic check that our input param "some-text" is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))

--- a/internal/ethereum/deploy_contract_prepare_test.go
+++ b/internal/ethereum/deploy_contract_prepare_test.go
@@ -96,37 +96,6 @@ const samplePrepareDeployTXLargeInputParams = `{
 	"params": [ 10000000000000000000000001, "some-text" ]
 }`
 
-const samplePrepareDeployTXScientificNotation = `{
-	"ffcapi": {
-		"version": "v1.0.0",
-		"id": "904F177C-C790-4B01-BDF4-F2B4E52E607E",
-		"type": "DeployContract"
-	},
-	"from": "0xb480F96c0a3d6E9e9a263e4665a39bFa6c4d01E8",
-	"to": "0xe1a078b9e2b145d0a7387f09277c6ae1d9470771",
-	"gas": 1000000,
-	"nonce": "111",
-	"value": "12345678901234567890123456789",
-	"contract": "0xdeadbeef",
-	"definition": [{
-		"inputs": [
-			{
-				"internalType":" uint256",
-				"name": "x",
-				"type": "uint256"
-			},
-		    {
-			    "internalType":" string",
-			    "name": "y",
-			    "type": "string"
-		    }
-		],
-		"outputs":[],
-		"type":"constructor"
-	}],
-	"params": [ 1.0000000000000000000000001e+25, "some-text" ]
-}`
-
 func TestDeployContractPrepareOkNoEstimate(t *testing.T) {
 
 	ctx, c, _, done := newTestConnector(t)
@@ -162,24 +131,6 @@ func TestDeployContractPrepareOkLargeInputParam(t *testing.T) {
 	assert.Equal(t, int64(1000000), res.Gas.Int64())
 
 	// Basic check that our input param 10000000000000000000000001 is in the TX data
-	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
-	// Basic check that our input param "some-text" is in the TX data
-	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))
-}
-
-func TestDeployContractPrepareOkScientificNotationParam(t *testing.T) {
-
-	ctx, c, _, done := newTestConnector(t)
-	defer done()
-
-	var req ffcapi.ContractDeployPrepareRequest
-	err := json.Unmarshal([]byte(samplePrepareDeployTXScientificNotation), &req)
-	assert.NoError(t, err)
-	res, reason, err := c.DeployContractPrepare(ctx, &req)
-	assert.NoError(t, err)
-	assert.Empty(t, reason)
-	assert.Equal(t, int64(1000000), res.Gas.Int64())
-	// Basic check that our input param 1.0000000000000000000000001e+25 is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "84595161401484a000001"))
 	// Basic check that our input param "some-text" is in the TX data
 	assert.True(t, strings.Contains(res.TransactionData, "736f6d652d74657874"))

--- a/internal/ethereum/prepare_transaction.go
+++ b/internal/ethereum/prepare_transaction.go
@@ -108,7 +108,7 @@ func (c *ethConnector) prepareCallData(ctx context.Context, req *ffcapi.Transact
 	ethParams := make([]interface{}, len(req.Params))
 	for i, p := range req.Params {
 		if p != nil {
-			err := json.Unmarshal([]byte(*p), &ethParams[i])
+			err := p.Unmarshal(ctx, &ethParams[i])
 			if err != nil {
 				return nil, nil, i18n.NewError(ctx, msgs.MsgUnmarshalParamFail, i, err)
 			}


### PR DESCRIPTION
This PR does 2 things:

1. Pulls in the latest version of:
   - `firefly-common` (see especially PR https://github.com/hyperledger/firefly-common/pull/147)
   - `firefly-signer` (see especially PR https://github.com/hyperledger/firefly-signer/pull/76)
   - `firefly-transaction-manager` (see especially PR https://github.com/hyperledger/firefly-transaction-manager/pull/128)
3. Adds unit tests that exercise the new function introduced by those PRs