### PR TITLE
Handle duplicate block number in the same getFilterChanges call

### DIFF
--- a/internal/ethereum/blocklistener.go
+++ b/internal/ethereum/blocklistener.go
@@ -199,6 +199,7 @@ func (bl *blockListener) listenLoop() {
 			failCount++
 			continue
 		}
+		log.L(bl.ctx).Debugf("Block filter received new block hashes: %+v", blockHashes)
 
 		update := &ffcapi.BlockHashEvent{GapPotential: gapPotential, Created: fftypes.Now()}
 		var notifyPos *list.Element

--- a/internal/ethereum/blocklistener.go
+++ b/internal/ethereum/blocklistener.go
@@ -230,7 +230,7 @@ func (bl *blockListener) listenLoop() {
 			default:
 				candidate := bl.reconcileCanonicalChain(bi)
 				// Check this is the lowest position to notify from
-				if candidate != nil && (notifyPos == nil || candidate.Value.(*minimalBlockInfo).number < notifyPos.Value.(*minimalBlockInfo).number) {
+				if candidate != nil && (notifyPos == nil || candidate.Value.(*minimalBlockInfo).number <= notifyPos.Value.(*minimalBlockInfo).number) {
 					notifyPos = candidate
 				}
 			}

--- a/internal/ethereum/blocklistener_test.go
+++ b/internal/ethereum/blocklistener_test.go
@@ -355,6 +355,277 @@ func TestBlockListenerOKDuplicates(t *testing.T) {
 
 }
 
+func TestBlockListenerReorgKeepLatestHeadInSameBatch(t *testing.T) {
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.blockPollingInterval = 1 * time.Microsecond
+
+	block1000Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String()) // parent
+	block1001HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1001HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*ethtypes.HexInteger)
+		*hbh = *ethtypes.NewHexInteger64(1000)
+	}).Once()
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_newBlockFilter").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*string)
+		*hbh = "filter_id1"
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1001HashA,
+			block1001HashB,
+			block1002Hash,
+			block1003Hash,
+		}
+	}).Once()
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1001HashA.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001HashA,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1001HashB.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001HashB,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1002Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002Hash,
+			ParentHash: block1001HashB,
+		}
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003Hash,
+			ParentHash: block1002Hash,
+		}
+	})
+
+	updates := make(chan *ffcapi.BlockHashEvent)
+	bl.addConsumer(&blockUpdateConsumer{
+		id:      fftypes.NewUUID(),
+		ctx:     context.Background(),
+		updates: updates,
+	})
+
+	bu := <-updates
+	assert.Equal(t, []string{
+		block1001HashB.String(),
+		block1002Hash.String(),
+		block1003Hash.String(),
+	}, bu.BlockHashes)
+
+	done()
+	<-bl.listenLoopDone
+
+	assert.Equal(t, int64(1003), bl.highestBlock)
+
+	mRPC.AssertExpectations(t)
+}
+
+func TestBlockListenerReorgKeepLatestMiddleInSameBatch(t *testing.T) {
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.blockPollingInterval = 1 * time.Microsecond
+
+	block1000Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String()) // parent
+	block1001Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*ethtypes.HexInteger)
+		*hbh = *ethtypes.NewHexInteger64(1000)
+	}).Once()
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_newBlockFilter").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*string)
+		*hbh = "filter_id1"
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1001Hash,
+			block1002HashA,
+			block1002HashB,
+			block1003Hash,
+		}
+	}).Once()
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1001Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1002HashA.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002HashA,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1002HashB.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002HashB,
+			ParentHash: block1001Hash,
+		}
+	})
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003Hash,
+			ParentHash: block1002HashB,
+		}
+	})
+	updates := make(chan *ffcapi.BlockHashEvent)
+	bl.addConsumer(&blockUpdateConsumer{
+		id:      fftypes.NewUUID(),
+		ctx:     context.Background(),
+		updates: updates,
+	})
+
+	bu := <-updates
+	assert.Equal(t, []string{
+		block1001Hash.String(),
+		block1002HashB.String(),
+		block1003Hash.String(),
+	}, bu.BlockHashes)
+
+	done()
+	<-bl.listenLoopDone
+
+	assert.Equal(t, int64(1003), bl.highestBlock)
+
+	mRPC.AssertExpectations(t)
+}
+
+func TestBlockListenerReorgKeepLatestTailInSameBatch(t *testing.T) {
+
+	_, c, mRPC, done := newTestConnector(t)
+	bl := c.blockListener
+	bl.blockPollingInterval = 1 * time.Microsecond
+
+	block1000Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String()) // parent
+	block1001Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003HashB := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1002Hash := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+	block1003HashA := ethtypes.MustNewHexBytes0xPrefix(fftypes.NewRandB32().String())
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_blockNumber").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*ethtypes.HexInteger)
+		*hbh = *ethtypes.NewHexInteger64(1000)
+	}).Once()
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_newBlockFilter").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*string)
+		*hbh = "filter_id1"
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", "filter_id1").Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1001Hash,
+			block1002Hash,
+			block1003HashA,
+			block1003HashB,
+		}
+	}).Once()
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", mock.Anything).Return(nil)
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1001Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1001),
+			Hash:       block1001Hash,
+			ParentHash: block1000Hash,
+		}
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1002Hash.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1002),
+			Hash:       block1002Hash,
+			ParentHash: block1001Hash,
+		}
+	})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003HashA.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashA,
+			ParentHash: block1002Hash,
+		}
+	})
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
+		return bh == block1003HashB.String()
+	}), false).Return(nil).Run(func(args mock.Arguments) {
+		*args[1].(**blockInfoJSONRPC) = &blockInfoJSONRPC{
+			Number:     ethtypes.NewHexInteger64(1003),
+			Hash:       block1003HashB,
+			ParentHash: block1002Hash,
+		}
+	})
+	updates := make(chan *ffcapi.BlockHashEvent)
+	bl.addConsumer(&blockUpdateConsumer{
+		id:      fftypes.NewUUID(),
+		ctx:     context.Background(),
+		updates: updates,
+	})
+
+	bu := <-updates
+	assert.Equal(t, []string{
+		block1001Hash.String(),
+		block1002Hash.String(),
+		block1003HashB.String(),
+	}, bu.BlockHashes)
+
+	done()
+	<-bl.listenLoopDone
+
+	assert.Equal(t, int64(1003), bl.highestBlock)
+
+	mRPC.AssertExpectations(t)
+}
+
 func TestBlockListenerReorgReplaceTail(t *testing.T) {
 
 	_, c, mRPC, done := newTestConnector(t)


### PR DESCRIPTION
When the block hashes in the `eth_getFilterChanges` call has block number conflict, there is a edge case we don't handle.

This PR fixed the issue so that if the beginning block number has duplicate hashes in the same `eth_getFilterChanges` call, the logic should still be able to handle it.
