### PR TITLE
Chain ID included in events

### DIFF
--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -51,6 +51,7 @@ type ethConnector struct {
 	blockListener              *blockListener
 	eventFilterPollingInterval time.Duration
 	traceTXForRevertReason     bool
+	chainID                    string
 
 	mux          sync.Mutex
 	eventStreams map[fftypes.UUID]*eventStream

--- a/internal/ethereum/event_enricher.go
+++ b/internal/ethereum/event_enricher.go
@@ -63,7 +63,7 @@ func (ee *eventEnricher) filterEnrichEthLog(ctx context.Context, f *eventFilter,
 
 	info := eventInfo{
 		logJSONRPC: *ethLog,
-		ChainId:    ee.connector.chainID,
+		ChainID:    ee.connector.chainID,
 	}
 
 	var timestamp *fftypes.FFTime

--- a/internal/ethereum/event_enricher.go
+++ b/internal/ethereum/event_enricher.go
@@ -55,7 +55,8 @@ func (ee *eventEnricher) filterEnrichEthLog(ctx context.Context, f *eventFilter,
 	data, decoded := ee.decodeLogData(ctx, f.Event, ethLog.Topics, ethLog.Data)
 
 	info := eventInfo{
-		logJSONRPC: *ethLog,
+		logJSONRPC:      *ethLog,
+		ChainIdentifier: fftypes.JSONAnyPtr("asd"),
 	}
 
 	var timestamp *fftypes.FFTime

--- a/internal/ethereum/event_enricher.go
+++ b/internal/ethereum/event_enricher.go
@@ -19,7 +19,6 @@ package ethereum
 import (
 	"bytes"
 	"context"
-	"fmt"
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
@@ -64,9 +63,7 @@ func (ee *eventEnricher) filterEnrichEthLog(ctx context.Context, f *eventFilter,
 
 	info := eventInfo{
 		logJSONRPC: *ethLog,
-		ChainIdentifier: fftypes.JSONAnyPtr(fmt.Sprintf(`{
-			"chainId": "%s"
-		}`, ee.connector.chainID)),
+		ChainId:    ee.connector.chainID,
 	}
 
 	var timestamp *fftypes.FFTime

--- a/internal/ethereum/event_listener_test.go
+++ b/internal/ethereum/event_listener_test.go
@@ -169,6 +169,7 @@ func TestListenerCatchupErrorsThenDeliveryExit(t *testing.T) {
 	l.catchupLoopDone = make(chan struct{})
 	l.hwmBlock = 0
 
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(&rpcbackend.RPCError{Message: "12345"}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
 		return bh == "0x6b012339fbb85b70c58ecfd97b31950c4a28bcef5226e12dbe551cb1abaf3b4c"
 	}), false).Return(nil).Run(func(args mock.Arguments) {

--- a/internal/ethereum/event_listener_test.go
+++ b/internal/ethereum/event_listener_test.go
@@ -169,7 +169,9 @@ func TestListenerCatchupErrorsThenDeliveryExit(t *testing.T) {
 	l.catchupLoopDone = make(chan struct{})
 	l.hwmBlock = 0
 
-	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(&rpcbackend.RPCError{Message: "12345"}).Once()
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		l.ee.connector.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
 		return bh == "0x6b012339fbb85b70c58ecfd97b31950c4a28bcef5226e12dbe551cb1abaf3b4c"
 	}), false).Return(nil).Run(func(args mock.Arguments) {
@@ -195,6 +197,9 @@ func TestListenerCatchupScalesBackOnExpectedError(t *testing.T) {
 	l.catchupLoopDone = make(chan struct{})
 	l.hwmBlock = 0
 
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		l.ee.connector.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
 		return bh == "0x6b012339fbb85b70c58ecfd97b31950c4a28bcef5226e12dbe551cb1abaf3b4c"
 	}), false).Return(nil).Run(func(args mock.Arguments) {
@@ -222,6 +227,9 @@ func TestListenerCatchupScalesBackNTimesOnExpectedError(t *testing.T) {
 	l.catchupLoopDone = make(chan struct{})
 	l.hwmBlock = 0
 
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		l.ee.connector.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
 		return bh == "0x6b012339fbb85b70c58ecfd97b31950c4a28bcef5226e12dbe551cb1abaf3b4c"
 	}), false).Return(nil).Run(func(args mock.Arguments) {
@@ -249,6 +257,9 @@ func TestListenerCatchupScalesBackToOne(t *testing.T) {
 	l.catchupLoopDone = make(chan struct{})
 	l.hwmBlock = 0
 
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		l.ee.connector.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
 		return bh == "0x6b012339fbb85b70c58ecfd97b31950c4a28bcef5226e12dbe551cb1abaf3b4c"
 	}), false).Return(nil).Run(func(args mock.Arguments) {
@@ -276,6 +287,9 @@ func TestListenerNoCatchupScaleBackOnErrorMismatch(t *testing.T) {
 	l.catchupLoopDone = make(chan struct{})
 	l.hwmBlock = 0
 
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		l.ee.connector.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
 		return bh == "0x6b012339fbb85b70c58ecfd97b31950c4a28bcef5226e12dbe551cb1abaf3b4c"
 	}), false).Return(nil).Run(func(args mock.Arguments) {
@@ -307,6 +321,9 @@ func TestListenerCatchupScalesBackCustomRegex(t *testing.T) {
 
 	assert.NoError(t, err)
 
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		l.ee.connector.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
 		return bh == "0x6b012339fbb85b70c58ecfd97b31950c4a28bcef5226e12dbe551cb1abaf3b4c"
 	}), false).Return(nil).Run(func(args mock.Arguments) {
@@ -345,6 +362,10 @@ func TestListenerCatchupNoScaleBackEmptyRegex(t *testing.T) {
 			Number: ethtypes.NewHexInteger64(1001),
 		}
 	})
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		l.ee.connector.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getLogs", mock.Anything).Return(&rpcbackend.RPCError{Message: "ACME JSON/RPC endpoint error - eth_getLogs response size is too large"}).Times(5)
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getLogs", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		*args[1].(*[]*logJSONRPC) = []*logJSONRPC{sampleTransferLog()}
@@ -454,6 +475,9 @@ func TestFilterEnrichEthLogMethodInputsOk(t *testing.T) {
 	err := json.Unmarshal([]byte(abiTransferEvent), &abiEvent)
 	assert.NoError(t, err)
 
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		l.ee.connector.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByHash", mock.MatchedBy(func(bh string) bool {
 		return bh == "0x6b012339fbb85b70c58ecfd97b31950c4a28bcef5226e12dbe551cb1abaf3b4c"
 	}), false).Return(nil).Run(func(args mock.Arguments) {

--- a/internal/ethereum/event_stream.go
+++ b/internal/ethereum/event_stream.go
@@ -48,7 +48,7 @@ type eventInfo struct {
 	InputMethod string                 `json:"inputMethod,omitempty"` // the method invoked, if it matched one of the signatures in the listener definition
 	InputArgs   *fftypes.JSONAny       `json:"inputArgs,omitempty"`   // the method parameters, if the method matched one of the signatures in the listener definition
 	InputSigner *ethtypes.Address0xHex `json:"inputSigner,omitempty"` // the signing `from` address of the transaction
-	ChainId     string                 `json:"chainId,omitempty"`     // an identifier for the chain this event relates to
+	ChainID     string                 `json:"chainId,omitempty"`     // an identifier for the chain this event relates to
 }
 
 // eventStream is the state we hold in memory for each eventStream

--- a/internal/ethereum/event_stream.go
+++ b/internal/ethereum/event_stream.go
@@ -45,9 +45,10 @@ type eventFilter struct {
 // eventInfo is the top-level structure we pass to applications for each event (through the FFCAPI framework)
 type eventInfo struct {
 	logJSONRPC
-	InputMethod string                 `json:"inputMethod,omitempty"` // the method invoked, if it matched one of the signatures in the listener definition
-	InputArgs   *fftypes.JSONAny       `json:"inputArgs,omitempty"`   // the method parameters, if the method matched one of the signatures in the listener definition
-	InputSigner *ethtypes.Address0xHex `json:"inputSigner,omitempty"` // the signing `from` address of the transaction
+	InputMethod     string                 `json:"inputMethod,omitempty"`     // the method invoked, if it matched one of the signatures in the listener definition
+	InputArgs       *fftypes.JSONAny       `json:"inputArgs,omitempty"`       // the method parameters, if the method matched one of the signatures in the listener definition
+	InputSigner     *ethtypes.Address0xHex `json:"inputSigner,omitempty"`     // the signing `from` address of the transaction
+	ChainIdentifier *fftypes.JSONAny       `json:"chainIdentifier,omitempty"` // an identifier for the chain this event relates to
 }
 
 // eventStream is the state we hold in memory for each eventStream

--- a/internal/ethereum/event_stream.go
+++ b/internal/ethereum/event_stream.go
@@ -45,10 +45,10 @@ type eventFilter struct {
 // eventInfo is the top-level structure we pass to applications for each event (through the FFCAPI framework)
 type eventInfo struct {
 	logJSONRPC
-	InputMethod     string                 `json:"inputMethod,omitempty"`     // the method invoked, if it matched one of the signatures in the listener definition
-	InputArgs       *fftypes.JSONAny       `json:"inputArgs,omitempty"`       // the method parameters, if the method matched one of the signatures in the listener definition
-	InputSigner     *ethtypes.Address0xHex `json:"inputSigner,omitempty"`     // the signing `from` address of the transaction
-	ChainIdentifier *fftypes.JSONAny       `json:"chainIdentifier,omitempty"` // an identifier for the chain this event relates to
+	InputMethod string                 `json:"inputMethod,omitempty"` // the method invoked, if it matched one of the signatures in the listener definition
+	InputArgs   *fftypes.JSONAny       `json:"inputArgs,omitempty"`   // the method parameters, if the method matched one of the signatures in the listener definition
+	InputSigner *ethtypes.Address0xHex `json:"inputSigner,omitempty"` // the signing `from` address of the transaction
+	ChainId     string                 `json:"chainId,omitempty"`     // an identifier for the chain this event relates to
 }
 
 // eventStream is the state we hold in memory for each eventStream

--- a/internal/ethereum/event_stream_test.go
+++ b/internal/ethereum/event_stream_test.go
@@ -51,6 +51,7 @@ func testEventStreamExistingConnector(t *testing.T, ctx context.Context, done fu
 	es := c.eventStreams[*esID]
 	es.c.eventFilterPollingInterval = 1 * time.Millisecond
 	es.c.retry.MaximumDelay = 1 * time.Microsecond
+	c.chainID = "12345"
 	assert.NotNil(t, es)
 
 	es.preStartProcessing()

--- a/internal/ethereum/get_receipt_test.go
+++ b/internal/ethereum/get_receipt_test.go
@@ -572,6 +572,9 @@ func TestGetReceiptEventDecodeOK(t *testing.T) {
 	ctx, c, mRPC, done := newTestConnector(t)
 	defer done()
 
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "net_version", mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		c.chainID = "12345"
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getTransactionReceipt",
 		"0x7d48ae971faf089878b57e3c28e3035540d34f38af395958d2c73c36c57c83a2").
 		Return(nil).

--- a/internal/ethereum/statuses.go
+++ b/internal/ethereum/statuses.go
@@ -30,8 +30,7 @@ func (c *ethConnector) IsLive(_ context.Context) (*ffcapi.LiveResponse, ffcapi.E
 }
 
 func (c *ethConnector) IsReady(ctx context.Context) (*ffcapi.ReadyResponse, ffcapi.ErrorReason, error) {
-	var chainID string
-	err := c.backend.CallRPC(ctx, &chainID, "net_version")
+	err := c.backend.CallRPC(ctx, &c.chainID, "net_version")
 	if err != nil {
 		return &ffcapi.ReadyResponse{
 			Ready: false,
@@ -39,7 +38,7 @@ func (c *ethConnector) IsReady(ctx context.Context) (*ffcapi.ReadyResponse, ffca
 	}
 
 	details := &fftypes.JSONObject{
-		"chainID": chainID,
+		"chainID": c.chainID,
 	}
 
 	return &ffcapi.ReadyResponse{


### PR DESCRIPTION
There are cases where it is useful to identify which EVM chain an event has been published from:

1. A web socket application may be connected to multiple FF namespaces and be receiving events from multiple underlying blockchains
2. A web socket application may be connected to a single FF namespace, but that FF namespace is then recreated with a different name but using the same underlying blockchain

An application could bind FF namespace to a given chain, but this can be brittle as per `2` above.

An application could also assume that for a given contract address the events must be coming from a given chain. But since contract address is a function of sending account and nonce, a contract address can be identical across different chains.

Below is an example `blockchain_event_received` received through FireFly with this PR in place:

```
{
    "id": "4c648899-60ab-4afd-b3e7-6aac78a8df3d",
    "sequence": 75,
    "type": "blockchain_event_received",
    "namespace": "default",
    "reference": "66a65b0b-a58f-4bc7-9fc4-e19cf517fdb0",
    "topic": "test2",
    "created": "2025-04-04T09:10:37.300099174Z",
    "blockchainEvent": {
        "id": "66a65b0b-a58f-4bc7-9fc4-e19cf517fdb0",
        "source": "ethereum",
        "namespace": "default",
        "name": "ValueChanged",
        "listener": "f2e1f912-40a0-46db-9b22-81bfd9cd8bb5",
        "protocolId": "000000000025/000000/000000",
        "output": {
            "newValue": "1223443635445"
        },
        "info": {
            "address": "0x3550a858347c784694ad398f6864afe8f39742a6",
            "blockHash": "0xfced1ea30dca36cf2c888de2e847cc7010a1a314d21731db2ca9551be6ed4b01",
            "blockNumber": "25",
            "chainId": "2021",                              <<--  chain ID from the underlying blockchain
            "listenerId": "0195fb57-ceb1-1fa3-6e97-00d7018ddb74",
            "listenerName": "ff-sub-default-f2e1f912-40a0-46db-9b22-81bfd9cd8bb5",
            "listenerType": "events",
            "logIndex": "0",
            "removed": false,
            "signature": "ValueChanged(uint256)",
            "streamId": "0195dcd5-6714-fce7-0f38-d5e3cc7e99a7",
            "subId": "0195fb57-ceb1-1fa3-6e97-00d7018ddb74",
            "timestamp": "2025-04-04T09:10:36Z",
            "topics": [
                "0x93fe6d397c74fdf1402a8b72e47b68512f0510d7b98a4bc4cbdf6ac7108b3c59"
            ],
            "transactionHash": "0xd3c821f3941a214f05e773ed217ec6b42a7c1e41ecbdf33c1022983f96f2e7ab",
            "transactionIndex": "0"
        },
        "timestamp": "2025-04-04T09:10:36Z",
        "tx": {
            "blockchainId": "0xd3c821f3941a214f05e773ed217ec6b42a7c1e41ecbdf33c1022983f96f2e7ab"
        }
    },
    "subscription": {
        "id": "87bb2b9e-ef09-4bb9-9382-415bc5137575",
        "namespace": "default",
        "name": "87bb2b9e-ef09-4bb9-9382-415bc5137575"
    }
}
```

This PR adds `chainId` to the `info` payload provided by `evmconnect`. Other connectors could choose to include the same field. It's possible that FF would benefit from it being elevated to a first-class FF event field. Since that is a wider-reaching change I've gone with the smaller change of including it in `evmconnect`-specific form for now. This doesn't prevent it being added to the main `blockchainEvent` fields in the future.