### PR TITLE
Expose ws rpc

### DIFF
--- a/internal/ethereum/blocklistener.go
+++ b/internal/ethereum/blocklistener.go
@@ -27,7 +27,6 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-common/pkg/i18n"
 	"github.com/hyperledger/firefly-common/pkg/log"
-	"github.com/hyperledger/firefly-common/pkg/wsclient"
 	"github.com/hyperledger/firefly-evmconnect/internal/msgs"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/hyperledger/firefly-signer/pkg/rpcbackend"
@@ -72,11 +71,12 @@ type minimalBlockInfo struct {
 	parentHash string
 }
 
-func newBlockListener(ctx context.Context, c *ethConnector, conf config.Section, wsConf *wsclient.WSConfig) (bl *blockListener, err error) {
+func newBlockListener(ctx context.Context, c *ethConnector, conf config.Section) (bl *blockListener, err error) {
 	bl = &blockListener{
 		ctx:                        log.WithLogField(ctx, "role", "blocklistener"),
 		c:                          c,
 		backend:                    c.backend, // use the HTTP backend - might get overwritten by a connected websocket later
+		wsBackend:                  c.wsBackend,
 		isStarted:                  false,
 		startDone:                  make(chan struct{}),
 		initialBlockHeightObtained: make(chan struct{}),
@@ -88,9 +88,7 @@ func newBlockListener(ctx context.Context, c *ethConnector, conf config.Section,
 		unstableHeadLength:         int(c.checkpointBlockGap),
 		hederaCompatibilityMode:    conf.GetBool(HederaCompatibilityMode),
 	}
-	if wsConf != nil {
-		bl.wsBackend = rpcbackend.NewWSRPCClient(wsConf)
-	}
+
 	bl.blockCache, err = lru.New(conf.GetInt(BlockCacheSize))
 	if err != nil {
 		return nil, i18n.WrapError(ctx, err, msgs.MsgCacheInitFail, "block")

--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -61,7 +61,12 @@ type ethConnector struct {
 
 type Connector interface {
 	ffcapi.API
+
+	// RPC returns the http JSON/RPC client
 	RPC() rpcbackend.RPC
+
+	// WSRPC returns the websocket JSON/RPC client
+	// NOTE: websocket client will be nil if websockets are not enabled
 	WSRPC() rpcbackend.WebSocketRPCClient
 }
 


### PR DESCRIPTION
Adding another function `WSRPC()` to expose the websocket RPC client.

> NOTE: the websocket RPC client is optional, so the client should check whether it's nil

The HTTP RPC client is already exposed by the `RPC()` function.