### PR TITLE
Enable retry by default for 429 status code

### DIFF
--- a/config.md
+++ b/config.md
@@ -122,7 +122,7 @@
 |Key|Description|Type|Default Value|
 |---|-----------|----|-------------|
 |count|The maximum number of times to retry|`int`|`5`
-|enabled|Enables retries|`boolean`|`false`
+|enabled|Enables retries|`boolean`|`true`
 |errorStatusCodeRegex|The regex that the error response status code must match to trigger retry|`string`|`<nil>`
 |factor|(Deprecated) Please refer to `connector.queryLoopRetry.factor` to understand its original purpose and use that instead|`float32`|`2`
 |initWaitTime|The initial retry delay|[`time.Duration`](https://pkg.go.dev/time#Duration)|`250ms`

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/hyperledger/firefly-common v1.5.9
 	github.com/hyperledger/firefly-signer v1.1.21
-	github.com/hyperledger/firefly-transaction-manager v1.4.2
+	github.com/hyperledger/firefly-transaction-manager v1.4.3-0.20251210154150-19fe03d63b4f
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/golang-lru v1.0.2
 	github.com/hyperledger/firefly-common v1.5.9
 	github.com/hyperledger/firefly-signer v1.1.21
-	github.com/hyperledger/firefly-transaction-manager v1.4.3-0.20251210154150-19fe03d63b4f
+	github.com/hyperledger/firefly-transaction-manager v1.4.3
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/hyperledger/firefly-signer v1.1.21 h1:r7cTOw6e/6AtiXLf84wZy6Z7zppzlc1
 github.com/hyperledger/firefly-signer v1.1.21/go.mod h1:axrlSQeKrd124UdHF5L3MkTjb5DeTcbJxJNCZ3JmcWM=
 github.com/hyperledger/firefly-transaction-manager v1.4.3-0.20251210154150-19fe03d63b4f h1:i38DovJn5Dmme2Ltye4iv51UEwLpWkzfcQ78lGC/i9k=
 github.com/hyperledger/firefly-transaction-manager v1.4.3-0.20251210154150-19fe03d63b4f/go.mod h1:1kbYt8ofDXqfwC02vwV/HoOjmiv0IuT9UkJ//bbrliE=
+github.com/hyperledger/firefly-transaction-manager v1.4.3 h1:/RltpJCIH8VsB8cTEICbGJkyc1CGPpJ2grG3kV+tdc8=
+github.com/hyperledger/firefly-transaction-manager v1.4.3/go.mod h1:1kbYt8ofDXqfwC02vwV/HoOjmiv0IuT9UkJ//bbrliE=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,6 @@ github.com/hyperledger/firefly-common v1.5.9 h1:Z1+SuKNYJ8hPKQ5CvcsMg6r/E4RyW6wb
 github.com/hyperledger/firefly-common v1.5.9/go.mod h1:1Xawm5PUhxT7k+CL/Kr3i1LE3cTTzoQwZMLimvlW8rs=
 github.com/hyperledger/firefly-signer v1.1.21 h1:r7cTOw6e/6AtiXLf84wZy6Z7zppzlc191HokW2hv4N4=
 github.com/hyperledger/firefly-signer v1.1.21/go.mod h1:axrlSQeKrd124UdHF5L3MkTjb5DeTcbJxJNCZ3JmcWM=
-github.com/hyperledger/firefly-transaction-manager v1.4.2 h1:RbEY+ieLFKHpCl192OXQdD8WEoYlwY5+MMHr6gnTVes=
-github.com/hyperledger/firefly-transaction-manager v1.4.2/go.mod h1:1kbYt8ofDXqfwC02vwV/HoOjmiv0IuT9UkJ//bbrliE=
 github.com/hyperledger/firefly-transaction-manager v1.4.3-0.20251210154150-19fe03d63b4f h1:i38DovJn5Dmme2Ltye4iv51UEwLpWkzfcQ78lGC/i9k=
 github.com/hyperledger/firefly-transaction-manager v1.4.3-0.20251210154150-19fe03d63b4f/go.mod h1:1kbYt8ofDXqfwC02vwV/HoOjmiv0IuT9UkJ//bbrliE=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/hyperledger/firefly-signer v1.1.21 h1:r7cTOw6e/6AtiXLf84wZy6Z7zppzlc1
 github.com/hyperledger/firefly-signer v1.1.21/go.mod h1:axrlSQeKrd124UdHF5L3MkTjb5DeTcbJxJNCZ3JmcWM=
 github.com/hyperledger/firefly-transaction-manager v1.4.2 h1:RbEY+ieLFKHpCl192OXQdD8WEoYlwY5+MMHr6gnTVes=
 github.com/hyperledger/firefly-transaction-manager v1.4.2/go.mod h1:1kbYt8ofDXqfwC02vwV/HoOjmiv0IuT9UkJ//bbrliE=
+github.com/hyperledger/firefly-transaction-manager v1.4.3-0.20251210154150-19fe03d63b4f h1:i38DovJn5Dmme2Ltye4iv51UEwLpWkzfcQ78lGC/i9k=
+github.com/hyperledger/firefly-transaction-manager v1.4.3-0.20251210154150-19fe03d63b4f/go.mod h1:1kbYt8ofDXqfwC02vwV/HoOjmiv0IuT9UkJ//bbrliE=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=

--- a/internal/ethereum/config.go
+++ b/internal/ethereum/config.go
@@ -40,6 +40,9 @@ const (
 	DeprecatedRetryMaxDelay  = "retry.maxDelay"
 	DeprecatedRetryFactor    = "retry.factor"
 
+	// Open retry enabled
+	RetryEnabled = "retry.enabled"
+
 	MaxConcurrentRequests   = "maxConcurrentRequests"
 	TxCacheSize             = "txCacheSize"
 	HederaCompatibilityMode = "hederaCompatibilityMode"
@@ -84,4 +87,8 @@ func InitConfig(conf config.Section) {
 	conf.AddKnownKey(TxCacheSize, 250)
 	conf.AddKnownKey(HederaCompatibilityMode, false)
 	conf.AddKnownKey(TraceTXForRevertReason, false)
+
+	// FireFly Common default for retry enabled is false,
+	// but we want to enable it by default
+	conf.SetDefault(RetryEnabled, true)
 }

--- a/internal/ethereum/config.go
+++ b/internal/ethereum/config.go
@@ -40,7 +40,6 @@ const (
 	DeprecatedRetryMaxDelay  = "retry.maxDelay"
 	DeprecatedRetryFactor    = "retry.factor"
 
-	// Open retry enabled
 	RetryEnabled = "retry.enabled"
 
 	MaxConcurrentRequests   = "maxConcurrentRequests"

--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -122,12 +122,14 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connecto
 		// Set retry defaults for 429 responses if not already configured
 		if !httpConf.Retry {
 			httpConf.Retry = true
+			// We only set the default if the regex is not already set, to avoid overriding a user-provided regex.
+			// and changing the existing behavior of retrying everything if retry.enabled is true by the user
+			if httpConf.RetryErrorStatusCodeRegex == "" && !conf.IsSet(ffresty.HTTPConfigRetryErrorStatusCodeRegex) {
+				defaultRetryErrorStatusCodeRegex := "(?:429)"
+				httpConf.RetryErrorStatusCodeRegex = defaultRetryErrorStatusCodeRegex
+			}
 		}
 
-		if httpConf.RetryErrorStatusCodeRegex == "" && !conf.IsSet(ffresty.HTTPConfigRetryErrorStatusCodeRegex) {
-			const defaultRetryErrorStatusCodeRegex = "(?:429)"
-			httpConf.RetryErrorStatusCodeRegex = defaultRetryErrorStatusCodeRegex
-		}
 	}
 	httpClient := ffresty.NewWithConfig(ctx, *httpConf)
 	c.backend = rpcbackend.NewRPCClientWithOption(httpClient, rpcbackend.RPCClientOptions{

--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -113,24 +113,26 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connecto
 		// not as a full replacement for HTTP.
 		wsConf, err = wsclient.GenerateConfig(ctx, conf)
 	}
+
 	if err == nil {
 		httpConf, err = ffresty.GenerateConfig(ctx, conf)
-		if err != nil {
-			return nil, err
-		}
-
-		// Set retry defaults for 429 responses if not already configured
-		if !httpConf.Retry {
-			httpConf.Retry = true
-			// We only set the default if the regex is not already set, to avoid overriding a user-provided regex.
-			// and changing the existing behavior of retrying everything if retry.enabled is true by the user
-			if httpConf.RetryErrorStatusCodeRegex == "" && !conf.IsSet(ffresty.HTTPConfigRetryErrorStatusCodeRegex) {
-				defaultRetryErrorStatusCodeRegex := "(?:429)"
-				httpConf.RetryErrorStatusCodeRegex = defaultRetryErrorStatusCodeRegex
-			}
-		}
-
 	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Set retry defaults for 429 responses if not already configured
+	if !httpConf.Retry {
+		httpConf.Retry = true
+		// We only set the default if the regex is not already set, to avoid overriding a user-provided regex.
+		// and changing the existing behavior of retrying everything if retry.enabled is true by the user
+		if httpConf.RetryErrorStatusCodeRegex == "" && !conf.IsSet(ffresty.HTTPConfigRetryErrorStatusCodeRegex) {
+			defaultRetryErrorStatusCodeRegex := "(?:429)"
+			httpConf.RetryErrorStatusCodeRegex = defaultRetryErrorStatusCodeRegex
+		}
+	}
+
 	httpClient := ffresty.NewWithConfig(ctx, *httpConf)
 	c.backend = rpcbackend.NewRPCClientWithOption(httpClient, rpcbackend.RPCClientOptions{
 		MaxConcurrentRequest: conf.GetInt64(MaxConcurrentRequests),

--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -122,9 +122,9 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connecto
 		return nil, err
 	}
 
-	// Set retry defaults for 429 responses if not already configured
-	if !httpConf.Retry {
-		httpConf.Retry = true
+	// Only enable retry for 429 responses if the user has not xplicitly enabled it
+	// As this regressions the default behavior of what to retry
+	if !conf.IsSet(RetryEnabled) {
 		// We only set the default if the regex is not already set, to avoid overriding a user-provided regex.
 		// and changing the existing behavior of retrying everything if retry.enabled is true by the user
 		if httpConf.RetryErrorStatusCodeRegex == "" && !conf.IsSet(ffresty.HTTPConfigRetryErrorStatusCodeRegex) {

--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -122,17 +122,6 @@ func NewEthereumConnector(ctx context.Context, conf config.Section) (cc Connecto
 		return nil, err
 	}
 
-	// Only enable retry for 429 responses if the user has not xplicitly enabled it
-	// As this regressions the default behavior of what to retry
-	if !conf.IsSet(RetryEnabled) {
-		// We only set the default if the regex is not already set, to avoid overriding a user-provided regex.
-		// and changing the existing behavior of retrying everything if retry.enabled is true by the user
-		if httpConf.RetryErrorStatusCodeRegex == "" && !conf.IsSet(ffresty.HTTPConfigRetryErrorStatusCodeRegex) {
-			defaultRetryErrorStatusCodeRegex := "(?:429)"
-			httpConf.RetryErrorStatusCodeRegex = defaultRetryErrorStatusCodeRegex
-		}
-	}
-
 	httpClient := ffresty.NewWithConfig(ctx, *httpConf)
 	c.backend = rpcbackend.NewRPCClientWithOption(httpClient, rpcbackend.RPCClientOptions{
 		MaxConcurrentRequest: conf.GetInt64(MaxConcurrentRequests),


### PR DESCRIPTION
We encountered an issue where retry is not enabled by default and I believe it should. This is critical client side properly that should be enabled and specifically in the case 429s where the only option is to retry and more importantly using exponential backoff. 

This extends on the great work from @Chengxuan to add a Regex pattern to filter on specific status code to retry on done in FireFly Common. 

Notice how the FireFly-Signer uses the raw resty.Client but we create one from ffresty with the correct retry behavior.

This has migration concerns and needs to be clarified in release notes.

Added a comprehensive test that spins up a simple HTTP server to mock the RPC interaction because I could not mock the creation of RPC client and mocking the actual client made no sense.

