### PR TITLE
fix: race condition in conditional mock test

### DIFF
--- a/internal/ethereum/blocklistener_test.go
+++ b/internal/ethereum/blocklistener_test.go
@@ -108,16 +108,13 @@ func TestBlockListenerOKSequential(t *testing.T) {
 		hbh := args[1].(*string)
 		*hbh = testBlockFilterID1
 	})
-	conditionalMockOnce(
-		mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", testBlockFilterID1).Return(nil),
-		func() bool { return len(bl.consumers) > 0 },
-		func(args mock.Arguments) {
-			hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
-			*hbh = []ethtypes.HexBytes0xPrefix{
-				block1001Hash,
-				block1002Hash,
-			}
-		})
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", testBlockFilterID1).Return(nil).Run(func(args mock.Arguments) {
+		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
+		*hbh = []ethtypes.HexBytes0xPrefix{
+			block1001Hash,
+			block1002Hash,
+		}
+	}).Once()
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getFilterChanges", testBlockFilterID1).Return(nil).Run(func(args mock.Arguments) {
 		hbh := args[1].(*[]ethtypes.HexBytes0xPrefix)
 		*hbh = []ethtypes.HexBytes0xPrefix{


### PR DESCRIPTION
There was  a race condition in the test on the way the consumers are added and we way for that , a cursor breakdown  was useful 

```
Timeline:
────────────────────────────────────────────────────────────────────
Test calls bl.addConsumer()
    │
    ├─► checkAndStartListenerLoop() ─► starts listener goroutine
    │
    ├─► waitUntilStarted() ◄─── BLOCKS HERE
    │                               │
    │       ┌───────────────────────┘
    │       │   Listener goroutine runs:
    │       │     1. eth_blockNumber ✓
    │       │     2. eth_newBlockFilter ✓
    │       │     3. eth_getFilterChanges ← conditionalMockOnce checks consumers
    │       │                               len(bl.consumers) == 0 ❌
    │       │                               Returns EMPTY array!
    │       │     4. markStarted() ← unblocks waitUntilStarted
    │       └───────────────────────┐
    │                               │
    ├─► waitUntilStarted() returns ◄┘
    │
    └─► bl.consumers[id] = consumer  ← Consumer added TOO LATE!

Test waits on: bu := <-updates  ← Never receives anything, TIMEOUT!
```