### PR TITLE
fix: Only add address if the filter has an address

### DIFF
--- a/internal/ethereum/event_stream.go
+++ b/internal/ethereum/event_stream.go
@@ -542,7 +542,7 @@ func (es *eventStream) getBlockRangeEvents(ctx context.Context, ag *aggregatedLi
 		},
 	}
 
-	if len(ag.listeners) == 1 && len(ag.listeners[0].config.filters) == 1 {
+	if len(ag.listeners) == 1 && len(ag.listeners[0].config.filters) == 1 && ag.listeners[0].config.filters[0].Address != nil {
 		logFilterJSONRPCReq.Address = []*ethtypes.Address0xHex{ag.listeners[0].config.filters[0].Address}
 	}
 


### PR DESCRIPTION
With the new change in format of the `eth_getLogs` struct introduced in https://github.com/hyperledger/firefly-evmconnect/pull/180, specifically this line https://github.com/hyperledger/firefly-evmconnect/pull/180/changes#diff-4e2a6adc5b26a1ecc3c0d3ab0fc27cc76d98c5220c89a79302112dcac8eef6e2R536-R546 . In the case of a filter that has **no** address configured it would result in this JSON RPC call

```json
{
  "jsonrpc": "2.0",
  "id": 1,
  "method": "eth_getLogs",
  "params": [
    {
      "fromBlock": "0x45c5d",
      "toBlock": "0x45e90",
      "address": [null],
      "topics": [
        ["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"]
      ]
    }
  ]
}
```

Which throws:
```json
{
    "jsonrpc": "2.0",
    "id": 1,
    "error": {
        "code": -32602,
        "message": "Invalid filter params"
    }
}
```

This PR only sets the address field if an address is set.

@peterbroadhurst @Chengxuan , not sure why here we don's pass in multiple addressed? I believe we do the filtering for that client side potentially