### PR TITLE
Missing maxFeePerGas/maxPriorityFeePerGas and uint64 consistency

### DIFF
--- a/internal/ethereum/event_enricher.go
+++ b/internal/ethereum/event_enricher.go
@@ -93,7 +93,7 @@ func (ee *eventEnricher) filterEnrichEthLog(ctx context.Context, f *eventFilter,
 			log.L(ctx).Errorf("Failed to get block info timestamp for block '%s': block not found", ethLog.BlockHash)
 			return nil, matched, decoded, i18n.NewError(ctx, msgs.MsgBlockNotAvailable)
 		}
-		timestamp = fftypes.UnixTime(bi.Timestamp.BigInt().Int64())
+		timestamp = fftypes.UnixTime(int64(bi.Timestamp.Uint64())) // nolint:gosec // this is what it is - we don't accept negative time, and unix doesn't support full uint64 range
 	}
 
 	if len(methods) > 0 || ee.extractSigner {

--- a/internal/ethereum/get_receipt.go
+++ b/internal/ethereum/get_receipt.go
@@ -224,7 +224,7 @@ func (c *ethConnector) TransactionReceipt(ctx context.Context, req *ffcapi.Trans
 // enrichTransactionReceipt tries to get the error information
 func (c *ethConnector) enrichTransactionReceipt(ctx context.Context, ethReceipt *ethrpc.TxReceiptJSONRPC) *ffcapi.TransactionReceiptResponse {
 
-	isSuccess := (ethReceipt.Status != nil && ethReceipt.Status.BigInt().Int64() > 0)
+	isSuccess := (ethReceipt.Status != nil && *ethReceipt.Status > 0)
 
 	var returnDataString *string
 	var transactionErrorMessage *string
@@ -233,13 +233,17 @@ func (c *ethConnector) enrichTransactionReceipt(ctx context.Context, ethReceipt 
 		returnDataString, transactionErrorMessage = c.getErrorInfo(ctx, ethReceipt.TransactionHash.String(), ethReceipt.RevertReason)
 	}
 
+	var status *big.Int
+	if ethReceipt.Status != nil {
+		status = new(big.Int).SetUint64(ethReceipt.Status.Uint64())
+	}
 	fullReceipt, _ := json.Marshal(&receiptExtraInfo{
 		ContractAddress:   ethReceipt.ContractAddress,
 		CumulativeGasUsed: (*fftypes.FFBigInt)(ethReceipt.CumulativeGasUsed),
 		From:              ethReceipt.From,
 		To:                ethReceipt.To,
 		GasUsed:           (*fftypes.FFBigInt)(ethReceipt.GasUsed),
-		Status:            (*fftypes.FFBigInt)(ethReceipt.Status),
+		Status:            (*fftypes.FFBigInt)(status),
 		ReturnValue:       returnDataString,
 		ErrorMessage:      transactionErrorMessage,
 	})

--- a/internal/ethereum/get_receipt.go
+++ b/internal/ethereum/get_receipt.go
@@ -45,7 +45,7 @@ type receiptExtraInfo struct {
 	From              *ethtypes.Address0xHex `json:"from"`
 	To                *ethtypes.Address0xHex `json:"to"`
 	GasUsed           *fftypes.FFBigInt      `json:"gasUsed"`
-	Status            *fftypes.FFBigInt      `json:"status"`
+	Status            *uint64                `json:"status"`
 	ErrorMessage      *string                `json:"errorMessage"`
 	ReturnValue       *string                `json:"returnValue,omitempty"`
 }
@@ -233,17 +233,13 @@ func (c *ethConnector) enrichTransactionReceipt(ctx context.Context, ethReceipt 
 		returnDataString, transactionErrorMessage = c.getErrorInfo(ctx, ethReceipt.TransactionHash.String(), ethReceipt.RevertReason)
 	}
 
-	var status *big.Int
-	if ethReceipt.Status != nil {
-		status = new(big.Int).SetUint64(ethReceipt.Status.Uint64())
-	}
 	fullReceipt, _ := json.Marshal(&receiptExtraInfo{
 		ContractAddress:   ethReceipt.ContractAddress,
 		CumulativeGasUsed: (*fftypes.FFBigInt)(ethReceipt.CumulativeGasUsed),
 		From:              ethReceipt.From,
 		To:                ethReceipt.To,
 		GasUsed:           (*fftypes.FFBigInt)(ethReceipt.GasUsed),
-		Status:            (*fftypes.FFBigInt)(status),
+		Status:            (*uint64)(ethReceipt.Status),
 		ReturnValue:       returnDataString,
 		ErrorMessage:      transactionErrorMessage,
 	})

--- a/internal/msgs/en_field_descriptions.go
+++ b/internal/msgs/en_field_descriptions.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Kaleido, Inc.
+// Copyright © 2026 Kaleido, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/msgs/en_field_descriptions.go
+++ b/internal/msgs/en_field_descriptions.go
@@ -1,0 +1,105 @@
+// Copyright © 2023 Kaleido, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package msgs
+
+import (
+	"github.com/hyperledger/firefly-common/pkg/i18n"
+	"golang.org/x/text/language"
+)
+
+var ffm = func(key, translation string) i18n.MessageKey {
+	return i18n.FFM(language.AmericanEnglish, key, translation)
+}
+
+var (
+	// https://ethereum.org/developers/docs/apis/json-rpc/#eth_gettransactionreceipt
+	_ = ffm("TxReceiptJSONRPC.transactionHash", "DATA, 32 Bytes - hash of the transaction.")
+	_ = ffm("TxReceiptJSONRPC.transactionIndex", "QUANTITY - integer of the transactions index position in the block.")
+	_ = ffm("TxReceiptJSONRPC.blockHash", "DATA, 32 Bytes - hash of the block where this transaction was in.")
+	_ = ffm("TxReceiptJSONRPC.blockNumber", "QUANTITY - block number where this transaction was in.")
+	_ = ffm("TxReceiptJSONRPC.from", "DATA, 20 Bytes - address of the sender.")
+	_ = ffm("TxReceiptJSONRPC.to", "DATA, 20 Bytes - address of the receiver. null when its a contract creation transaction.")
+	_ = ffm("TxReceiptJSONRPC.cumulativeGasUsed", "QUANTITY - The total amount of gas used when this transaction was executed in the block.")
+	_ = ffm("TxReceiptJSONRPC.effectiveGasPrice", "QUANTITY - The sum of the base fee and tip paid per unit of gas.")
+	_ = ffm("TxReceiptJSONRPC.gasUsed", "QUANTITY - The amount of gas used by this specific transaction alone.")
+	_ = ffm("TxReceiptJSONRPC.contractAddress", "DATA, 20 Bytes - The contract address created, if the transaction was a contract creation, otherwise null.")
+	_ = ffm("TxReceiptJSONRPC.logs", "Array - Array of log objects, which this transaction generated.")
+	_ = ffm("TxReceiptJSONRPC.logsBloom", "DATA, 256 Bytes - Bloom filter for light clients to quickly retrieve related logs.")
+	_ = ffm("TxReceiptJSONRPC.type", "QUANTITY - integer of the transaction type, 0x0 for legacy transactions, 0x1 for access list types, 0x2 for dynamic fees.")
+	_ = ffm("TxReceiptJSONRPC.status", "QUANTITY either 1 (success) or 0 (failure)")
+	_ = ffm("TxReceiptJSONRPC.revertReason", "Non-standard extension: The encoded revert data for the transaction")
+
+	// https://ethereum.org/developers/docs/apis/json-rpc/#eth_gettransactionbyhash
+	_ = ffm("TxInfoJSONRPC.chainId", "QUANTITY - the chain id.")
+	_ = ffm("TxInfoJSONRPC.blockHash", "DATA, 32 Bytes - hash of the block where this transaction was in. null when its pending.")
+	_ = ffm("TxInfoJSONRPC.blockNumber", "QUANTITY - block number where this transaction was in. null when its pending.")
+	_ = ffm("TxInfoJSONRPC.from", "DATA, 20 Bytes - address of the sender.")
+	_ = ffm("TxInfoJSONRPC.gas", "QUANTITY - gas provided by the sender.")
+	_ = ffm("TxInfoJSONRPC.gasPrice", "QUANTITY - gas price provided by the sender in Wei.")
+	_ = ffm("TxInfoJSONRPC.hash", "DATA, 32 Bytes - hash of the transaction.")
+	_ = ffm("TxInfoJSONRPC.input", "DATA - the data send along with the transaction.")
+	_ = ffm("TxInfoJSONRPC.nonce", "QUANTITY - the number of transactions made by the sender prior to this one.")
+	_ = ffm("TxInfoJSONRPC.to", "DATA, 20 Bytes - address of the receiver. null when its a contract creation transaction.")
+	_ = ffm("TxInfoJSONRPC.transactionIndex", "QUANTITY - integer of the transactions index position in the block. null when its pending.")
+	_ = ffm("TxInfoJSONRPC.value", "QUANTITY - value transferred in Wei.")
+	_ = ffm("TxInfoJSONRPC.v", "QUANTITY - ECDSA recovery id")
+	_ = ffm("TxInfoJSONRPC.r", "QUANTITY - ECDSA signature r")
+	_ = ffm("TxInfoJSONRPC.s", "QUANTITY - ECDSA signature s")
+	_ = ffm("TxInfoJSONRPC.type", "QUANTITY - integer of the transaction type, 0x0 for legacy transactions, 0x1 for access list types, 0x2 for dynamic fees.")
+	// https://ethereum.org/developers/docs/transactions/#whats-a-transaction
+	_ = ffm("TxInfoJSONRPC.maxPriorityFeePerGas", `QUANTITY - the maximum price of the consumed gas to be included as a tip to the validator.`)
+	_ = ffm("TxInfoJSONRPC.maxFeePerGas", `QUANTITY - the maximum fee per unit of gas willing to be paid for the transaction (inclusive of baseFeePerGas and maxPriorityFeePerGas).`)
+
+	// https://ethereum.org/developers/docs/apis/json-rpc/#eth_getlogs
+	_ = ffm("LogFilterJSONRPC.fromBlock", `QUANTITY|TAG - (optional, default: "latest") Integer block number, or "latest" for the last proposed block, "safe" for the latest safe block, "finalized" for the latest finalized block, or "pending", "earliest" for transactions not yet in a block.`)
+	_ = ffm("LogFilterJSONRPC.toBlock", `QUANTITY|TAG - (optional, default: "latest") Integer block number, or "latest" for the last proposed block, "safe" for the latest safe block, "finalized" for the latest finalized block, or "pending", "earliest" for transactions not yet in a block.`)
+	_ = ffm("LogFilterJSONRPC.address", `DATA|Array, 20 Bytes - (optional) Contract address or a list of addresses from which logs should originate.`)
+	_ = ffm("LogFilterJSONRPC.topics", `Array of DATA, - (optional) Array of 32 Bytes DATA topics. Topics are order-dependent. Each topic can also be an array of DATA with "or" options.`)
+
+	// https://ethereum.org/developers/docs/apis/json-rpc/#eth_getfilterchanges
+	_ = ffm("LogJSONRPC.removed", `TAG - true when the log was removed, due to a chain reorganization. false if its a valid log.`)
+	_ = ffm("LogJSONRPC.logIndex", `QUANTITY - integer of the log index position in the block. null when its pending log.`)
+	_ = ffm("LogJSONRPC.transactionIndex", `QUANTITY - integer of the transactions index position log was created from. null when its pending log.`)
+	_ = ffm("LogJSONRPC.transactionHash", `DATA, 32 Bytes - hash of the transactions this log was created from. null when its pending log.`)
+	_ = ffm("LogJSONRPC.blockHash", `DATA, 32 Bytes - hash of the block where this log was in. null when its pending. null when its pending log.`)
+	_ = ffm("LogJSONRPC.blockNumber", `QUANTITY - the block number where this log was in. null when its pending. null when its pending log.`)
+	_ = ffm("LogJSONRPC.address", `DATA, 20 Bytes - address from which this log originated.`)
+	_ = ffm("LogJSONRPC.data", `DATA - variable-length non-indexed log data. (In solidity: zero or more 32 Bytes non-indexed log arguments.)`)
+	_ = ffm("LogJSONRPC.topics", `Array of DATA - Array of 0 to 4 32 Bytes DATA of indexed log arguments. (In solidity: The first topic is the hash of the signature of the event (e.g., Deposit(address,bytes32,uint256)), except you declared the event with the anonymous specifier.)`)
+
+	_ = ffm("BlockInfoJSONRPC.number", `QUANTITY - the block number. null when its pending block.`)
+	_ = ffm("BlockInfoJSONRPC.hash", `DATA, 32 Bytes - hash of the block. null when its pending block.`)
+	_ = ffm("BlockInfoJSONRPC.parentHash", `DATA, 32 Bytes - hash of the parent block.`)
+	_ = ffm("BlockInfoJSONRPC.nonce", `DATA, 8 Bytes - hash of the generated proof-of-work. null when its pending block, 0x0 for proof-of-stake blocks (since The Merge)`)
+	_ = ffm("BlockInfoJSONRPC.sha3Uncles", `DATA, 32 Bytes - SHA3 of the uncles data in the block.`)
+	_ = ffm("BlockInfoJSONRPC.logsBloom", `DATA, 256 Bytes - the bloom filter for the logs of the block. null when its pending block.`)
+	_ = ffm("BlockInfoJSONRPC.transactionsRoot", `DATA, 32 Bytes - the root of the transaction trie of the block.`)
+	_ = ffm("BlockInfoJSONRPC.stateRoot", `DATA, 32 Bytes - the root of the final state trie of the block.`)
+	_ = ffm("BlockInfoJSONRPC.receiptsRoot", `DATA, 32 Bytes - the root of the receipts trie of the block.`)
+	_ = ffm("BlockInfoJSONRPC.miner", `DATA, 20 Bytes - the address of the beneficiary to whom the block rewards were given.`)
+	_ = ffm("BlockInfoJSONRPC.mixHash", `DATA, a 256-bit hash encoded as a hexadecimal string.`)
+	_ = ffm("BlockInfoJSONRPC.difficulty", `QUANTITY - integer of the difficulty for this block.`)
+	_ = ffm("BlockInfoJSONRPC.totalDifficulty", `QUANTITY - integer of the total difficulty of the chain until this block.`)
+	_ = ffm("BlockInfoJSONRPC.extraData", `DATA - the "extra data" field of this block.`)
+	_ = ffm("BlockInfoJSONRPC.size", `QUANTITY - integer the size of this block in bytes.`)
+	_ = ffm("BlockInfoJSONRPC.gasLimit", `QUANTITY - the maximum gas allowed in this block.`)
+	_ = ffm("BlockInfoJSONRPC.gasUsed", `QUANTITY - the total used gas by all transactions in this block.`)
+	_ = ffm("BlockInfoJSONRPC.timestamp", `QUANTITY - the unix timestamp for when the block was collated.`)
+	_ = ffm("BlockInfoJSONRPC.transactions", `Array - Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.`)
+	_ = ffm("BlockInfoJSONRPC.uncles", `Array - Array of uncle hashes.`)
+	_ = ffm("BlockInfoJSONRPC.baseFeePerGas", `QUANTITY - the market price for gas`)
+)

--- a/pkg/ethrpc/ethrpc.go
+++ b/pkg/ethrpc/ethrpc.go
@@ -89,8 +89,8 @@ type TxInfoJSONRPC struct {
 	Input                ethtypes.HexBytes0xPrefix `json:"input"`
 	Nonce                *ethtypes.HexInteger      `json:"nonce"`
 	To                   *ethtypes.Address0xHex    `json:"to"`
-	TransactionIndex     *ethtypes.HexInteger      `json:"transactionIndex"` // null if pending
-	Type                 *ethtypes.HexInteger      `json:"type"`
+	TransactionIndex     *ethtypes.HexUint64       `json:"transactionIndex"` // null if pending
+	Type                 *ethtypes.HexUint64       `json:"type"`
 	Value                *ethtypes.HexInteger      `json:"value"`
 	V                    *ethtypes.HexInteger      `json:"v"`
 	R                    *ethtypes.HexInteger      `json:"r"`
@@ -114,8 +114,8 @@ func (txi *TxInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalO
 		"input":                ([]byte)(txi.Input),
 		"nonce":                (*big.Int)(txi.Nonce),
 		"to":                   (*[20]byte)(txi.To),
-		"transactionIndex":     (*big.Int)(txi.TransactionIndex),
-		"type":                 (*big.Int)(txi.Type),
+		"transactionIndex":     (*uint64)(txi.TransactionIndex),
+		"type":                 (*uint64)(txi.Type),
 		"value":                (*big.Int)(txi.Value),
 		"v":                    (*big.Int)(txi.V),
 		"r":                    (*big.Int)(txi.R),

--- a/pkg/ethrpc/ethrpc.go
+++ b/pkg/ethrpc/ethrpc.go
@@ -39,8 +39,8 @@ type TxReceiptJSONRPC struct {
 	ContractAddress   *ethtypes.Address0xHex    `json:"contractAddress"`
 	Logs              []*LogJSONRPC             `json:"logs"`
 	LogsBloom         ethtypes.HexBytes0xPrefix `json:"logsBloom"`
-	Type              *ethtypes.HexInteger      `json:"type"`
-	Status            *ethtypes.HexInteger      `json:"status"`
+	Type              *ethtypes.HexUint64       `json:"type"`
+	Status            *ethtypes.HexUint64       `json:"status"`
 	RevertReason      ethtypes.HexBytes0xPrefix `json:"revertReason"`
 }
 
@@ -65,8 +65,8 @@ func (txr *TxReceiptJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...Marsh
 			"contractAddress":   (*[20]byte)(txr.ContractAddress),
 			"logs":              logsArray,
 			"logsBloom":         ([]byte)(txr.LogsBloom),
-			"status":            (*big.Int)(txr.Status),
-			"type":              (*big.Int)(txr.Type),
+			"status":            (*uint64)(txr.Status),
+			"type":              (*uint64)(txr.Type),
 			"revertReason":      ([]byte)(txr.RevertReason),
 		}, append(opts, MarshalOption{
 			OmitNullFields: []string{"revertReason"},
@@ -77,43 +77,50 @@ func (txr *TxReceiptJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...Marsh
 
 // TxInfoJSONRPC is the transaction info obtained over JSON/RPC from the ethereum client, with input data
 type TxInfoJSONRPC struct {
-	BlockHash        ethtypes.HexBytes0xPrefix `json:"blockHash"`   // null if pending
-	BlockNumber      ethtypes.HexUint64        `json:"blockNumber"` // null if pending
-	ChainID          *ethtypes.HexInteger      `json:"chainId"`
-	From             *ethtypes.Address0xHex    `json:"from"`
-	Gas              *ethtypes.HexInteger      `json:"gas"`
-	GasPrice         *ethtypes.HexInteger      `json:"gasPrice"`
-	Hash             ethtypes.HexBytes0xPrefix `json:"hash"`
-	Input            ethtypes.HexBytes0xPrefix `json:"input"`
-	Nonce            *ethtypes.HexInteger      `json:"nonce"`
-	To               *ethtypes.Address0xHex    `json:"to"`
-	TransactionIndex *ethtypes.HexInteger      `json:"transactionIndex"` // null if pending
-	Type             *ethtypes.HexInteger      `json:"type"`
-	Value            *ethtypes.HexInteger      `json:"value"`
-	V                *ethtypes.HexInteger      `json:"v"`
-	R                *ethtypes.HexInteger      `json:"r"`
-	S                *ethtypes.HexInteger      `json:"s"`
+	BlockHash            ethtypes.HexBytes0xPrefix `json:"blockHash"`   // null if pending
+	BlockNumber          ethtypes.HexUint64        `json:"blockNumber"` // null if pending
+	ChainID              *ethtypes.HexInteger      `json:"chainId"`
+	From                 *ethtypes.Address0xHex    `json:"from"`
+	Gas                  *ethtypes.HexInteger      `json:"gas"`
+	GasPrice             *ethtypes.HexInteger      `json:"gasPrice"`
+	MaxFeePerGas         *ethtypes.HexInteger      `json:"maxFeePerGas"`
+	MaxPriorityFeePerGas *ethtypes.HexInteger      `json:"maxPriorityFeePerGas"`
+	Hash                 ethtypes.HexBytes0xPrefix `json:"hash"`
+	Input                ethtypes.HexBytes0xPrefix `json:"input"`
+	Nonce                *ethtypes.HexInteger      `json:"nonce"`
+	To                   *ethtypes.Address0xHex    `json:"to"`
+	TransactionIndex     *ethtypes.HexInteger      `json:"transactionIndex"` // null if pending
+	Type                 *ethtypes.HexInteger      `json:"type"`
+	Value                *ethtypes.HexInteger      `json:"value"`
+	V                    *ethtypes.HexInteger      `json:"v"`
+	R                    *ethtypes.HexInteger      `json:"r"`
+	S                    *ethtypes.HexInteger      `json:"s"`
 }
 
 func (txi *TxInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (_ json.RawMessage, err error) {
+	optsWithNulls := make([]MarshalOption, 0, len(opts)+1)
+	optsWithNulls = append(optsWithNulls, MarshalOption{OmitNullFields: []string{"maxFeePerGas", "maxPriorityFeePerGas", "gasPrice"}})
+	optsWithNulls = append(optsWithNulls, opts...)
 	return jss.MarshalFormattedMap(map[string]any{
-		"blockHash":        ([]byte)(txi.BlockHash),
-		"blockNumber":      (*uint64)(&txi.BlockNumber),
-		"chainId":          (*big.Int)(txi.ChainID),
-		"from":             (*[20]byte)(txi.From),
-		"gas":              (*big.Int)(txi.Gas),
-		"gasPrice":         (*big.Int)(txi.GasPrice),
-		"hash":             ([]byte)(txi.Hash),
-		"input":            ([]byte)(txi.Input),
-		"nonce":            (*big.Int)(txi.Nonce),
-		"to":               (*[20]byte)(txi.To),
-		"transactionIndex": (*big.Int)(txi.TransactionIndex),
-		"type":             (*big.Int)(txi.Type),
-		"value":            (*big.Int)(txi.Value),
-		"v":                (*big.Int)(txi.V),
-		"r":                (*big.Int)(txi.R),
-		"s":                (*big.Int)(txi.S),
-	}, opts...)
+		"blockHash":            ([]byte)(txi.BlockHash),
+		"blockNumber":          (*uint64)(&txi.BlockNumber),
+		"chainId":              (*big.Int)(txi.ChainID),
+		"from":                 (*[20]byte)(txi.From),
+		"gas":                  (*big.Int)(txi.Gas),
+		"gasPrice":             (*big.Int)(txi.GasPrice),
+		"maxFeePerGas":         (*big.Int)(txi.MaxFeePerGas),
+		"maxPriorityFeePerGas": (*big.Int)(txi.MaxPriorityFeePerGas),
+		"hash":                 ([]byte)(txi.Hash),
+		"input":                ([]byte)(txi.Input),
+		"nonce":                (*big.Int)(txi.Nonce),
+		"to":                   (*[20]byte)(txi.To),
+		"transactionIndex":     (*big.Int)(txi.TransactionIndex),
+		"type":                 (*big.Int)(txi.Type),
+		"value":                (*big.Int)(txi.Value),
+		"v":                    (*big.Int)(txi.V),
+		"r":                    (*big.Int)(txi.R),
+		"s":                    (*big.Int)(txi.S),
+	}, optsWithNulls...)
 }
 
 // See https://ethereum.org/hr/developers/docs/apis/json-rpc/#eth_newfilter
@@ -161,7 +168,7 @@ type BlockInfoJSONRPC struct {
 	Number       ethtypes.HexUint64          `json:"number"`
 	Hash         ethtypes.HexBytes0xPrefix   `json:"hash"`
 	ParentHash   ethtypes.HexBytes0xPrefix   `json:"parentHash"`
-	Timestamp    *ethtypes.HexInteger        `json:"timestamp"`
+	Timestamp    ethtypes.HexUint64          `json:"timestamp"`
 	LogsBloom    ethtypes.HexBytes0xPrefix   `json:"logsBloom"`
 	Transactions []ethtypes.HexBytes0xPrefix `json:"transactions"`
 }
@@ -175,7 +182,7 @@ func (bi *BlockInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...Marsha
 		"number":       (*uint64)(&bi.Number),
 		"hash":         ([]byte)(bi.Hash),
 		"parentHash":   ([]byte)(bi.ParentHash),
-		"timestamp":    (*big.Int)(bi.Timestamp),
+		"timestamp":    (*uint64)(&bi.Timestamp),
 		"logsBloom":    ([]byte)(bi.LogsBloom),
 		"transactions": txnArray,
 	}, opts...)
@@ -218,7 +225,7 @@ type BlockHeaderJSONRPC struct {
 	Size             *ethtypes.HexInteger        `json:"size"`
 	GasLimit         *ethtypes.HexInteger        `json:"gasLimit"`
 	GasUsed          *ethtypes.HexInteger        `json:"gasUsed"`
-	Timestamp        *ethtypes.HexInteger        `json:"timestamp"`
+	Timestamp        ethtypes.HexUint64          `json:"timestamp"`
 	Uncles           []ethtypes.HexBytes0xPrefix `json:"uncles"`
 }
 
@@ -246,7 +253,7 @@ func (b *BlockHeaderJSONRPC) getFormatMap() map[string]any {
 		"size":             (*big.Int)(b.Size),
 		"gasLimit":         (*big.Int)(b.GasLimit),
 		"gasUsed":          (*big.Int)(b.GasUsed),
-		"timestamp":        (*big.Int)(b.Timestamp),
+		"timestamp":        (*uint64)(&b.Timestamp),
 		"uncles":           unclesArray,
 	}
 }

--- a/pkg/ethrpc/ethrpc.go
+++ b/pkg/ethrpc/ethrpc.go
@@ -27,21 +27,21 @@ import (
 
 // TxReceiptJSONRPC is the receipt obtained over JSON/RPC from the ethereum client, with gas used, logs and contract address
 type TxReceiptJSONRPC struct {
-	TransactionHash   ethtypes.HexBytes0xPrefix `json:"transactionHash"`
-	TransactionIndex  ethtypes.HexUint64        `json:"transactionIndex"`
-	BlockHash         ethtypes.HexBytes0xPrefix `json:"blockHash"`
-	BlockNumber       ethtypes.HexUint64        `json:"blockNumber"`
-	From              *ethtypes.Address0xHex    `json:"from"`
-	To                *ethtypes.Address0xHex    `json:"to"`
-	CumulativeGasUsed *ethtypes.HexInteger      `json:"cumulativeGasUsed"`
-	EffectiveGasPrice *ethtypes.HexInteger      `json:"effectiveGasPrice"`
-	GasUsed           *ethtypes.HexInteger      `json:"gasUsed"`
-	ContractAddress   *ethtypes.Address0xHex    `json:"contractAddress"`
-	Logs              []*LogJSONRPC             `json:"logs"`
-	LogsBloom         ethtypes.HexBytes0xPrefix `json:"logsBloom"`
-	Type              *ethtypes.HexUint64       `json:"type"`
-	Status            *ethtypes.HexUint64       `json:"status"`
-	RevertReason      ethtypes.HexBytes0xPrefix `json:"revertReason"`
+	TransactionHash   ethtypes.HexBytes0xPrefix `json:"transactionHash" ffstruct:"TxReceiptJSONRPC"`
+	TransactionIndex  ethtypes.HexUint64        `json:"transactionIndex" ffstruct:"TxReceiptJSONRPC"`
+	BlockHash         ethtypes.HexBytes0xPrefix `json:"blockHash" ffstruct:"TxReceiptJSONRPC"`
+	BlockNumber       ethtypes.HexUint64        `json:"blockNumber" ffstruct:"TxReceiptJSONRPC"`
+	From              *ethtypes.Address0xHex    `json:"from" ffstruct:"TxReceiptJSONRPC"`
+	To                *ethtypes.Address0xHex    `json:"to" ffstruct:"TxReceiptJSONRPC"`
+	CumulativeGasUsed *ethtypes.HexInteger      `json:"cumulativeGasUsed" ffstruct:"TxReceiptJSONRPC"`
+	EffectiveGasPrice *ethtypes.HexInteger      `json:"effectiveGasPrice" ffstruct:"TxReceiptJSONRPC"`
+	GasUsed           *ethtypes.HexInteger      `json:"gasUsed" ffstruct:"TxReceiptJSONRPC"`
+	ContractAddress   *ethtypes.Address0xHex    `json:"contractAddress" ffstruct:"TxReceiptJSONRPC"`
+	Logs              []*LogJSONRPC             `json:"logs" ffstruct:"TxReceiptJSONRPC"`
+	LogsBloom         ethtypes.HexBytes0xPrefix `json:"logsBloom" ffstruct:"TxReceiptJSONRPC"`
+	Type              *ethtypes.HexUint64       `json:"type" ffstruct:"TxReceiptJSONRPC"`
+	Status            *ethtypes.HexUint64       `json:"status" ffstruct:"TxReceiptJSONRPC"`
+	RevertReason      ethtypes.HexBytes0xPrefix `json:"revertReason" ffstruct:"TxReceiptJSONRPC"`
 }
 
 func (txr *TxReceiptJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (jb json.RawMessage, err error) {
@@ -77,24 +77,24 @@ func (txr *TxReceiptJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...Marsh
 
 // TxInfoJSONRPC is the transaction info obtained over JSON/RPC from the ethereum client, with input data
 type TxInfoJSONRPC struct {
-	BlockHash            ethtypes.HexBytes0xPrefix `json:"blockHash"`   // null if pending
-	BlockNumber          ethtypes.HexUint64        `json:"blockNumber"` // null if pending
-	ChainID              *ethtypes.HexInteger      `json:"chainId"`
-	From                 *ethtypes.Address0xHex    `json:"from"`
-	Gas                  *ethtypes.HexInteger      `json:"gas"`
-	GasPrice             *ethtypes.HexInteger      `json:"gasPrice"`
-	MaxFeePerGas         *ethtypes.HexInteger      `json:"maxFeePerGas"`
-	MaxPriorityFeePerGas *ethtypes.HexInteger      `json:"maxPriorityFeePerGas"`
-	Hash                 ethtypes.HexBytes0xPrefix `json:"hash"`
-	Input                ethtypes.HexBytes0xPrefix `json:"input"`
-	Nonce                *ethtypes.HexInteger      `json:"nonce"`
-	To                   *ethtypes.Address0xHex    `json:"to"`
-	TransactionIndex     *ethtypes.HexUint64       `json:"transactionIndex"` // null if pending
-	Type                 *ethtypes.HexUint64       `json:"type"`
-	Value                *ethtypes.HexInteger      `json:"value"`
-	V                    *ethtypes.HexInteger      `json:"v"`
-	R                    *ethtypes.HexInteger      `json:"r"`
-	S                    *ethtypes.HexInteger      `json:"s"`
+	BlockHash            ethtypes.HexBytes0xPrefix `json:"blockHash" ffstruct:"TxInfoJSONRPC"`   // null if pending
+	BlockNumber          ethtypes.HexUint64        `json:"blockNumber" ffstruct:"TxInfoJSONRPC"` // null if pending
+	ChainID              *ethtypes.HexInteger      `json:"chainId" ffstruct:"TxInfoJSONRPC"`
+	From                 *ethtypes.Address0xHex    `json:"from" ffstruct:"TxInfoJSONRPC"`
+	Gas                  *ethtypes.HexInteger      `json:"gas" ffstruct:"TxInfoJSONRPC"`
+	GasPrice             *ethtypes.HexInteger      `json:"gasPrice" ffstruct:"TxInfoJSONRPC"`
+	MaxFeePerGas         *ethtypes.HexInteger      `json:"maxFeePerGas" ffstruct:"TxInfoJSONRPC"`
+	MaxPriorityFeePerGas *ethtypes.HexInteger      `json:"maxPriorityFeePerGas" ffstruct:"TxInfoJSONRPC"`
+	Hash                 ethtypes.HexBytes0xPrefix `json:"hash" ffstruct:"TxInfoJSONRPC"`
+	Input                ethtypes.HexBytes0xPrefix `json:"input" ffstruct:"TxInfoJSONRPC"`
+	Nonce                *ethtypes.HexInteger      `json:"nonce" ffstruct:"TxInfoJSONRPC"`
+	To                   *ethtypes.Address0xHex    `json:"to" ffstruct:"TxInfoJSONRPC"`
+	TransactionIndex     *ethtypes.HexUint64       `json:"transactionIndex" ffstruct:"TxInfoJSONRPC"` // null if pending
+	Type                 *ethtypes.HexUint64       `json:"type" ffstruct:"TxInfoJSONRPC"`
+	Value                *ethtypes.HexInteger      `json:"value" ffstruct:"TxInfoJSONRPC"`
+	V                    *ethtypes.HexInteger      `json:"v" ffstruct:"TxInfoJSONRPC"`
+	R                    *ethtypes.HexInteger      `json:"r" ffstruct:"TxInfoJSONRPC"`
+	S                    *ethtypes.HexInteger      `json:"s" ffstruct:"TxInfoJSONRPC"`
 }
 
 func (txi *TxInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (_ json.RawMessage, err error) {
@@ -127,22 +127,22 @@ func (txi *TxInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalO
 // The address, as well as the entries in the topic array, can be DATA|Array.
 // We just use array in all cases.
 type LogFilterJSONRPC struct {
-	FromBlock *ethtypes.HexInteger          `json:"fromBlock,omitempty"`
-	ToBlock   *ethtypes.HexInteger          `json:"toBlock,omitempty"`
-	Address   []*ethtypes.Address0xHex      `json:"address,omitempty"`
-	Topics    [][]ethtypes.HexBytes0xPrefix `json:"topics,omitempty"`
+	FromBlock *ethtypes.HexInteger          `json:"fromBlock,omitempty" ffstruct:"LogFilterJSONRPC"`
+	ToBlock   *ethtypes.HexInteger          `json:"toBlock,omitempty" ffstruct:"LogFilterJSONRPC"`
+	Address   []*ethtypes.Address0xHex      `json:"address,omitempty" ffstruct:"LogFilterJSONRPC"`
+	Topics    [][]ethtypes.HexBytes0xPrefix `json:"topics,omitempty" ffstruct:"LogFilterJSONRPC"`
 }
 
 type LogJSONRPC struct {
-	Removed          bool                        `json:"removed"`
-	LogIndex         ethtypes.HexUint64          `json:"logIndex"`
-	TransactionIndex ethtypes.HexUint64          `json:"transactionIndex"`
-	BlockNumber      ethtypes.HexUint64          `json:"blockNumber"`
-	TransactionHash  ethtypes.HexBytes0xPrefix   `json:"transactionHash"`
-	BlockHash        ethtypes.HexBytes0xPrefix   `json:"blockHash"`
-	Address          *ethtypes.Address0xHex      `json:"address"`
-	Data             ethtypes.HexBytes0xPrefix   `json:"data"`
-	Topics           []ethtypes.HexBytes0xPrefix `json:"topics"`
+	Removed          bool                        `json:"removed" ffstruct:"LogJSONRPC"`
+	LogIndex         ethtypes.HexUint64          `json:"logIndex" ffstruct:"LogJSONRPC"`
+	TransactionIndex ethtypes.HexUint64          `json:"transactionIndex" ffstruct:"LogJSONRPC"`
+	BlockNumber      ethtypes.HexUint64          `json:"blockNumber" ffstruct:"LogJSONRPC"`
+	TransactionHash  ethtypes.HexBytes0xPrefix   `json:"transactionHash" ffstruct:"LogJSONRPC"`
+	BlockHash        ethtypes.HexBytes0xPrefix   `json:"blockHash" ffstruct:"LogJSONRPC"`
+	Address          *ethtypes.Address0xHex      `json:"address" ffstruct:"LogJSONRPC"`
+	Data             ethtypes.HexBytes0xPrefix   `json:"data" ffstruct:"LogJSONRPC"`
+	Topics           []ethtypes.HexBytes0xPrefix `json:"topics" ffstruct:"LogJSONRPC"`
 }
 
 func (l *LogJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (_ json.RawMessage, err error) {
@@ -165,12 +165,12 @@ func (l *LogJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption
 
 // BlockInfoJSONRPC are the info fields we parse from the JSON/RPC response, and cache
 type BlockInfoJSONRPC struct {
-	Number       ethtypes.HexUint64          `json:"number"`
-	Hash         ethtypes.HexBytes0xPrefix   `json:"hash"`
-	ParentHash   ethtypes.HexBytes0xPrefix   `json:"parentHash"`
-	Timestamp    ethtypes.HexUint64          `json:"timestamp"`
-	LogsBloom    ethtypes.HexBytes0xPrefix   `json:"logsBloom"`
-	Transactions []ethtypes.HexBytes0xPrefix `json:"transactions"`
+	Number       ethtypes.HexUint64          `json:"number" ffstruct:"BlockInfoJSONRPC"`
+	Hash         ethtypes.HexBytes0xPrefix   `json:"hash" ffstruct:"BlockInfoJSONRPC"`
+	ParentHash   ethtypes.HexBytes0xPrefix   `json:"parentHash" ffstruct:"BlockInfoJSONRPC"`
+	Timestamp    ethtypes.HexUint64          `json:"timestamp" ffstruct:"BlockInfoJSONRPC"`
+	LogsBloom    ethtypes.HexBytes0xPrefix   `json:"logsBloom" ffstruct:"BlockInfoJSONRPC"`
+	Transactions []ethtypes.HexBytes0xPrefix `json:"transactions" ffstruct:"BlockInfoJSONRPC"`
 }
 
 func (bi *BlockInfoJSONRPC) MarshalFormat(jss *JSONSerializerSet, opts ...MarshalOption) (_ json.RawMessage, err error) {
@@ -207,26 +207,26 @@ func (bi *BlockInfoJSONRPC) ToFFCAPIMinimalBlockInfo() *ffcapi.MinimalBlockInfo 
 }
 
 type BlockHeaderJSONRPC struct {
-	Number           ethtypes.HexUint64          `json:"number"`
-	Hash             ethtypes.HexBytes0xPrefix   `json:"hash"`
-	MixHash          ethtypes.HexBytes0xPrefix   `json:"mixHash"`
-	ParentHash       ethtypes.HexBytes0xPrefix   `json:"parentHash"`
-	Nonce            ethtypes.HexBytes0xPrefix   `json:"nonce"`
-	SHA3Uncles       ethtypes.HexBytes0xPrefix   `json:"sha3Uncles"`
-	LogsBloom        ethtypes.HexBytes0xPrefix   `json:"logsBloom"`
-	TransactionsRoot ethtypes.HexBytes0xPrefix   `json:"transactionsRoot"`
-	StateRoot        ethtypes.HexBytes0xPrefix   `json:"stateRoot"`
-	ReceiptsRoot     ethtypes.HexBytes0xPrefix   `json:"receiptsRoot"`
-	Miner            *ethtypes.Address0xHex      `json:"miner"`
-	Difficulty       *ethtypes.HexInteger        `json:"difficulty"`
-	TotalDifficulty  *ethtypes.HexInteger        `json:"totalDifficulty"`
-	ExtraData        ethtypes.HexBytes0xPrefix   `json:"extraData"`
-	BaseFeePerGas    *ethtypes.HexInteger        `json:"baseFeePerGas"`
-	Size             *ethtypes.HexInteger        `json:"size"`
-	GasLimit         *ethtypes.HexInteger        `json:"gasLimit"`
-	GasUsed          *ethtypes.HexInteger        `json:"gasUsed"`
-	Timestamp        ethtypes.HexUint64          `json:"timestamp"`
-	Uncles           []ethtypes.HexBytes0xPrefix `json:"uncles"`
+	Number           ethtypes.HexUint64          `json:"number" ffstruct:"BlockInfoJSONRPC"`
+	Hash             ethtypes.HexBytes0xPrefix   `json:"hash" ffstruct:"BlockInfoJSONRPC"`
+	MixHash          ethtypes.HexBytes0xPrefix   `json:"mixHash" ffstruct:"BlockInfoJSONRPC"`
+	ParentHash       ethtypes.HexBytes0xPrefix   `json:"parentHash" ffstruct:"BlockInfoJSONRPC"`
+	Nonce            ethtypes.HexBytes0xPrefix   `json:"nonce" ffstruct:"BlockInfoJSONRPC"`
+	SHA3Uncles       ethtypes.HexBytes0xPrefix   `json:"sha3Uncles" ffstruct:"BlockInfoJSONRPC"`
+	LogsBloom        ethtypes.HexBytes0xPrefix   `json:"logsBloom" ffstruct:"BlockInfoJSONRPC"`
+	TransactionsRoot ethtypes.HexBytes0xPrefix   `json:"transactionsRoot" ffstruct:"BlockInfoJSONRPC"`
+	StateRoot        ethtypes.HexBytes0xPrefix   `json:"stateRoot" ffstruct:"BlockInfoJSONRPC"`
+	ReceiptsRoot     ethtypes.HexBytes0xPrefix   `json:"receiptsRoot" ffstruct:"BlockInfoJSONRPC"`
+	Miner            *ethtypes.Address0xHex      `json:"miner" ffstruct:"BlockInfoJSONRPC"`
+	Difficulty       *ethtypes.HexInteger        `json:"difficulty" ffstruct:"BlockInfoJSONRPC"`
+	TotalDifficulty  *ethtypes.HexInteger        `json:"totalDifficulty" ffstruct:"BlockInfoJSONRPC"`
+	ExtraData        ethtypes.HexBytes0xPrefix   `json:"extraData" ffstruct:"BlockInfoJSONRPC"`
+	BaseFeePerGas    *ethtypes.HexInteger        `json:"baseFeePerGas" ffstruct:"BlockInfoJSONRPC"`
+	Size             *ethtypes.HexInteger        `json:"size" ffstruct:"BlockInfoJSONRPC"`
+	GasLimit         *ethtypes.HexInteger        `json:"gasLimit" ffstruct:"BlockInfoJSONRPC"`
+	GasUsed          *ethtypes.HexInteger        `json:"gasUsed" ffstruct:"BlockInfoJSONRPC"`
+	Timestamp        ethtypes.HexUint64          `json:"timestamp" ffstruct:"BlockInfoJSONRPC"`
+	Uncles           []ethtypes.HexBytes0xPrefix `json:"uncles" ffstruct:"BlockInfoJSONRPC"`
 }
 
 func (b *BlockHeaderJSONRPC) getFormatMap() map[string]any {
@@ -274,7 +274,7 @@ func (b *BlockHeaderJSONRPC) ToBlockInfo(includeLogsBloom bool) *BlockInfoJSONRP
 // EVMBlockWithTxHashesJSONRPC is the full JSON/RPC structure you get with "false" on eth_getBlockByNumber / eth_getBlockByHash
 type EVMBlockWithTxHashesJSONRPC struct {
 	BlockHeaderJSONRPC
-	Transactions []ethtypes.HexBytes0xPrefix `json:"transactions"`
+	Transactions []ethtypes.HexBytes0xPrefix `json:"transactions" ffstruct:"BlockInfoJSONRPC"`
 }
 
 func (b *EVMBlockWithTxHashesJSONRPC) ToBlockInfo(includeLogsBloom bool) *BlockInfoJSONRPC {
@@ -289,7 +289,7 @@ func (b *EVMBlockWithTxHashesJSONRPC) ToBlockInfo(includeLogsBloom bool) *BlockI
 // EVMBlockWithTransactionsJSONRPC is the full JSON/RPC structure you get with "true" on eth_getBlockByNumber / eth_getBlockByHash
 type EVMBlockWithTransactionsJSONRPC struct {
 	BlockHeaderJSONRPC
-	Transactions []*TxInfoJSONRPC `json:"transactions"`
+	Transactions []*TxInfoJSONRPC `json:"transactions" ffstruct:"BlockInfoJSONRPC"`
 }
 
 func (b *EVMBlockWithTransactionsJSONRPC) ToBlockInfo(includeLogsBloom bool) *BlockInfoJSONRPC {

--- a/pkg/ethrpc/ethrpc_test.go
+++ b/pkg/ethrpc/ethrpc_test.go
@@ -22,6 +22,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/hyperledger/firefly-common/pkg/ffapi"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/stretchr/testify/require"
 )
@@ -269,4 +270,15 @@ func TestBlockInfoIsParent(t *testing.T) {
 	}
 	require.True(t, bi1.IsParentOf(bi2))
 	require.False(t, bi2.IsParentOf(bi1))
+}
+
+func TestABIDocumented(t *testing.T) {
+	ffapi.CheckObjectDocumented(&TxReceiptJSONRPC{})
+	ffapi.CheckObjectDocumented(&TxInfoJSONRPC{})
+	ffapi.CheckObjectDocumented(&LogFilterJSONRPC{})
+	ffapi.CheckObjectDocumented(&LogJSONRPC{})
+	ffapi.CheckObjectDocumented(&BlockInfoJSONRPC{})
+	ffapi.CheckObjectDocumented(&BlockHeaderJSONRPC{})
+	ffapi.CheckObjectDocumented(&EVMBlockWithTxHashesJSONRPC{})
+	ffapi.CheckObjectDocumented(&EVMBlockWithTransactionsJSONRPC{})
 }


### PR DESCRIPTION
- Adds missing fields `maxFeePerGas`/`maxPriorityFeePerGas`
    - Also making these unset (rather than `null`) if missing
- Makes fields `uint64` where possible including `timestamp`, `status` and `transactionIndex`
    - This is based on the recent move to `uint64`
    - Note that `status` is still nillable
- Adds field descriptions for all JSON/RPC fields, and test to ensure they are there