### PR TITLE
Pure ethrpc interface on ethblocklistener rather than hybrid FFCAPI

### DIFF
--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -37,6 +37,7 @@ import (
 	"github.com/hyperledger/firefly-evmconnect/pkg/ethblocklistener"
 	"github.com/hyperledger/firefly-evmconnect/pkg/ethrpc"
 	"github.com/hyperledger/firefly-signer/pkg/abi"
+	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/hyperledger/firefly-signer/pkg/rpcbackend"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 )
@@ -203,7 +204,12 @@ func withDeprecatedConfFallback[T any](conf config.Section, getter func(string) 
 // It delegates to the blockListener's internal reconciliation logic.
 func (c *ethConnector) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ffcapi.MinimalBlockInfo, targetConfirmationCount uint64) (res *ffcapi.ConfirmationUpdateResult, err error) {
 	// Now we can start the reconciliation process
-	ethrpcRes, ethReceipt, err := c.blockListener.ReconcileConfirmationsForTransaction(ctx, txHash, ffcapiToEthRPCConfirmations(existingConfirmations), targetConfirmationCount)
+	var ethrpcRes *ethblocklistener.ConfirmationUpdateResult
+	var ethrpcReceipt *ethrpc.TxReceiptJSONRPC
+	ethrpcEC, err := ffcapiToEthRPCConfirmations(existingConfirmations)
+	if err == nil {
+		ethrpcRes, ethrpcReceipt, err = c.blockListener.ReconcileConfirmationsForTransaction(ctx, txHash, ethrpcEC, targetConfirmationCount)
+	}
 	if err == nil && ethrpcRes != nil {
 		res = &ffcapi.ConfirmationUpdateResult{
 			Confirmations:           ethRPCtoFFCAPIConfirmations(ethrpcRes.Confirmations),
@@ -212,23 +218,25 @@ func (c *ethConnector) ReconcileConfirmationsForTransaction(ctx context.Context,
 			Confirmed:               ethrpcRes.Confirmed,
 			TargetConfirmationCount: ethrpcRes.TargetConfirmationCount,
 		}
-		if ethReceipt != nil {
-			res.Receipt = c.enrichTransactionReceipt(ctx, ethReceipt)
+		if ethrpcReceipt != nil {
+			res.Receipt = c.enrichTransactionReceipt(ctx, ethrpcReceipt)
 		}
 	}
 	return res, err
 }
 
-func ffcapiToEthRPCConfirmations(ffcapiEC []*ffcapi.MinimalBlockInfo) []*ethrpc.MinimalBlockInfo {
-	ec := make([]*ethrpc.MinimalBlockInfo, len(ffcapiEC))
+func ffcapiToEthRPCConfirmations(ffcapiEC []*ffcapi.MinimalBlockInfo) (ec []*ethrpc.MinimalBlockInfo, err error) {
+	ec = make([]*ethrpc.MinimalBlockInfo, len(ffcapiEC))
 	for i, c := range ffcapiEC {
-		ec[i] = &ethrpc.MinimalBlockInfo{
-			BlockNumber: c.BlockNumber,
-			BlockHash:   c.BlockHash,
-			ParentHash:  c.ParentHash,
+		ec[i] = &ethrpc.MinimalBlockInfo{BlockNumber: c.BlockNumber}
+		if err == nil {
+			ec[i].BlockHash, err = ethtypes.NewHexBytes0xPrefix(c.BlockHash)
+		}
+		if err == nil {
+			ec[i].ParentHash, err = ethtypes.NewHexBytes0xPrefix(c.ParentHash)
 		}
 	}
-	return ec
+	return ec, err
 }
 
 func ethRPCtoFFCAPIConfirmations(ffcapiEC []*ethrpc.MinimalBlockInfo) []*ffcapi.MinimalBlockInfo {
@@ -236,8 +244,8 @@ func ethRPCtoFFCAPIConfirmations(ffcapiEC []*ethrpc.MinimalBlockInfo) []*ffcapi.
 	for i, c := range ffcapiEC {
 		ec[i] = &ffcapi.MinimalBlockInfo{
 			BlockNumber: c.BlockNumber,
-			BlockHash:   c.BlockHash,
-			ParentHash:  c.ParentHash,
+			BlockHash:   c.BlockHash.String(),
+			ParentHash:  c.ParentHash.String(),
 		}
 	}
 	return ec

--- a/internal/ethereum/ethereum.go
+++ b/internal/ethereum/ethereum.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hyperledger/firefly-evmconnect/internal/msgs"
 	"github.com/hyperledger/firefly-evmconnect/internal/retryutil"
 	"github.com/hyperledger/firefly-evmconnect/pkg/ethblocklistener"
+	"github.com/hyperledger/firefly-evmconnect/pkg/ethrpc"
 	"github.com/hyperledger/firefly-signer/pkg/abi"
 	"github.com/hyperledger/firefly-signer/pkg/rpcbackend"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
@@ -200,12 +201,44 @@ func withDeprecatedConfFallback[T any](conf config.Section, getter func(string) 
 
 // ReconcileConfirmationsForTransaction is the public API for reconciling transaction confirmations.
 // It delegates to the blockListener's internal reconciliation logic.
-func (c *ethConnector) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ffcapi.MinimalBlockInfo, targetConfirmationCount uint64) (*ffcapi.ConfirmationUpdateResult, error) {
+func (c *ethConnector) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ffcapi.MinimalBlockInfo, targetConfirmationCount uint64) (res *ffcapi.ConfirmationUpdateResult, err error) {
 	// Now we can start the reconciliation process
-	res, ethReceipt, err := c.blockListener.ReconcileConfirmationsForTransaction(ctx, txHash, existingConfirmations, targetConfirmationCount)
-	if err == nil && res != nil && ethReceipt != nil {
-		// We enrich the
-		res.Receipt = c.enrichTransactionReceipt(ctx, ethReceipt)
+	ethrpcRes, ethReceipt, err := c.blockListener.ReconcileConfirmationsForTransaction(ctx, txHash, ffcapiToEthRPCConfirmations(existingConfirmations), targetConfirmationCount)
+	if err == nil && ethrpcRes != nil {
+		res = &ffcapi.ConfirmationUpdateResult{
+			Confirmations:           ethRPCtoFFCAPIConfirmations(ethrpcRes.Confirmations),
+			Rebuilt:                 ethrpcRes.Rebuilt,
+			NewFork:                 ethrpcRes.NewFork,
+			Confirmed:               ethrpcRes.Confirmed,
+			TargetConfirmationCount: ethrpcRes.TargetConfirmationCount,
+		}
+		if ethReceipt != nil {
+			res.Receipt = c.enrichTransactionReceipt(ctx, ethReceipt)
+		}
 	}
 	return res, err
+}
+
+func ffcapiToEthRPCConfirmations(ffcapiEC []*ffcapi.MinimalBlockInfo) []*ethrpc.MinimalBlockInfo {
+	ec := make([]*ethrpc.MinimalBlockInfo, len(ffcapiEC))
+	for i, c := range ffcapiEC {
+		ec[i] = &ethrpc.MinimalBlockInfo{
+			BlockNumber: c.BlockNumber,
+			BlockHash:   c.BlockHash,
+			ParentHash:  c.ParentHash,
+		}
+	}
+	return ec
+}
+
+func ethRPCtoFFCAPIConfirmations(ffcapiEC []*ethrpc.MinimalBlockInfo) []*ffcapi.MinimalBlockInfo {
+	ec := make([]*ffcapi.MinimalBlockInfo, len(ffcapiEC))
+	for i, c := range ffcapiEC {
+		ec[i] = &ffcapi.MinimalBlockInfo{
+			BlockNumber: c.BlockNumber,
+			BlockHash:   c.BlockHash,
+			ParentHash:  c.ParentHash,
+		}
+	}
+	return ec
 }

--- a/internal/ethereum/ethereum_test.go
+++ b/internal/ethereum/ethereum_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hyperledger/firefly-common/pkg/fftls"
 	"github.com/hyperledger/firefly-evmconnect/mocks/ethblocklistenermocks"
 	"github.com/hyperledger/firefly-evmconnect/mocks/rpcbackendmocks"
+	"github.com/hyperledger/firefly-evmconnect/pkg/ethblocklistener"
 	"github.com/hyperledger/firefly-evmconnect/pkg/ethrpc"
 	"github.com/hyperledger/firefly-signer/pkg/abi"
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
@@ -257,10 +258,21 @@ func TestReconcileConfirmationsForTransaction(t *testing.T) {
 	mbl := ethblocklistenermocks.NewBlockListener(t)
 	c.blockListener = mbl
 	mbl.On("WaitClosed").Return()
-	mbl.On("ReconcileConfirmationsForTransaction", ctx, "hash1", []*ffcapi.MinimalBlockInfo{}, uint64(10)).
-		Return(&ffcapi.ConfirmationUpdateResult{}, &ethrpc.TxReceiptJSONRPC{}, nil)
+	mbl.On("ReconcileConfirmationsForTransaction", ctx, "hash1", []*ethrpc.MinimalBlockInfo{
+		{BlockNumber: 12345},
+	}, uint64(10)).
+		Return(
+			&ethblocklistener.ConfirmationUpdateResult{
+				Confirmations: []*ethrpc.MinimalBlockInfo{
+					{BlockNumber: 12345},
+				},
+			},
+			&ethrpc.TxReceiptJSONRPC{},
+			nil)
 
-	_, err := c.ReconcileConfirmationsForTransaction(ctx, "hash1", []*ffcapi.MinimalBlockInfo{}, 10)
+	_, err := c.ReconcileConfirmationsForTransaction(ctx, "hash1", []*ffcapi.MinimalBlockInfo{
+		{BlockNumber: 12345},
+	}, 10)
 	require.NoError(t, err)
 
 }

--- a/internal/ethereum/ethereum_test.go
+++ b/internal/ethereum/ethereum_test.go
@@ -259,12 +259,14 @@ func TestReconcileConfirmationsForTransaction(t *testing.T) {
 	c.blockListener = mbl
 	mbl.On("WaitClosed").Return()
 	mbl.On("ReconcileConfirmationsForTransaction", ctx, "hash1", []*ethrpc.MinimalBlockInfo{
-		{BlockNumber: 12345},
+		{BlockNumber: 12345, BlockHash: []byte{}, ParentHash: []byte{}},
 	}, uint64(10)).
 		Return(
 			&ethblocklistener.ConfirmationUpdateResult{
 				Confirmations: []*ethrpc.MinimalBlockInfo{
-					{BlockNumber: 12345},
+					{
+						BlockNumber: 12345,
+					},
 				},
 			},
 			&ethrpc.TxReceiptJSONRPC{},

--- a/mocks/ethblocklistenermocks/block_listener.go
+++ b/mocks/ethblocklistenermocks/block_listener.go
@@ -10,8 +10,6 @@ import (
 
 	ethtypes "github.com/hyperledger/firefly-signer/pkg/ethtypes"
 
-	ffcapi "github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
-
 	fftypes "github.com/hyperledger/firefly-common/pkg/fftypes"
 
 	mock "github.com/stretchr/testify/mock"
@@ -281,28 +279,28 @@ func (_m *BlockListener) GetMonitoredHeadLength() int {
 }
 
 // ReconcileConfirmationsForTransaction provides a mock function with given fields: ctx, txHash, existingConfirmations, targetConfirmationCount
-func (_m *BlockListener) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ffcapi.MinimalBlockInfo, targetConfirmationCount uint64) (*ffcapi.ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error) {
+func (_m *BlockListener) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ethrpc.MinimalBlockInfo, targetConfirmationCount uint64) (*ethblocklistener.ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error) {
 	ret := _m.Called(ctx, txHash, existingConfirmations, targetConfirmationCount)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ReconcileConfirmationsForTransaction")
 	}
 
-	var r0 *ffcapi.ConfirmationUpdateResult
+	var r0 *ethblocklistener.ConfirmationUpdateResult
 	var r1 *ethrpc.TxReceiptJSONRPC
 	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, []*ffcapi.MinimalBlockInfo, uint64) (*ffcapi.ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, []*ethrpc.MinimalBlockInfo, uint64) (*ethblocklistener.ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error)); ok {
 		return rf(ctx, txHash, existingConfirmations, targetConfirmationCount)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, []*ffcapi.MinimalBlockInfo, uint64) *ffcapi.ConfirmationUpdateResult); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, string, []*ethrpc.MinimalBlockInfo, uint64) *ethblocklistener.ConfirmationUpdateResult); ok {
 		r0 = rf(ctx, txHash, existingConfirmations, targetConfirmationCount)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*ffcapi.ConfirmationUpdateResult)
+			r0 = ret.Get(0).(*ethblocklistener.ConfirmationUpdateResult)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, []*ffcapi.MinimalBlockInfo, uint64) *ethrpc.TxReceiptJSONRPC); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, string, []*ethrpc.MinimalBlockInfo, uint64) *ethrpc.TxReceiptJSONRPC); ok {
 		r1 = rf(ctx, txHash, existingConfirmations, targetConfirmationCount)
 	} else {
 		if ret.Get(1) != nil {
@@ -310,7 +308,7 @@ func (_m *BlockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string, []*ffcapi.MinimalBlockInfo, uint64) error); ok {
+	if rf, ok := ret.Get(2).(func(context.Context, string, []*ethrpc.MinimalBlockInfo, uint64) error); ok {
 		r2 = rf(ctx, txHash, existingConfirmations, targetConfirmationCount)
 	} else {
 		r2 = ret.Error(2)

--- a/pkg/ethblocklistener/blocklistener.go
+++ b/pkg/ethblocklistener/blocklistener.go
@@ -38,16 +38,17 @@ import (
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 )
 
+// a linked list of accumulated confirmations for a transaction
+// the list is sorted by block number
+//   - the first block is the block that contains the transaction hash
+//   - the last block is the most recent confirmation
+//
+// this list can be used as input to the future reconcile request to avoid re-fetching the blocks if they are no longer
+// in the in-memory partial chain
+// WARNING: mutation to this list is not expected, invalid modifications will cause inefficiencies in the reconciliation process
+//
+//	`rebuilt` will be true if an invalid confirmation list is detected by the reconciliation process
 type ConfirmationUpdateResult struct {
-	Receipt *ethrpc.TxReceiptJSONRPC `json:"receipt,omitempty"` // receipt for the transaction
-	// a linked list of accumulated confirmations for a transaction
-	// the list is sorted by block number
-	//    - the first block is the block that contains the transaction hash
-	//    - the last block is the most recent confirmation
-	// this list can be used as input to the future reconcile request to avoid re-fetching the blocks if they are no longer
-	// in the in-memory partial chain
-	// WARNING: mutation to this list is not expected, invalid modifications will cause inefficiencies in the reconciliation process
-	//          `rebuilt` will be true if an invalid confirmation list is detected by the reconciliation process
 	Confirmations           []*ethrpc.MinimalBlockInfo `json:"confirmations,omitempty"`
 	Rebuilt                 bool                       `json:"rebuilt,omitempty"`       // when true, it means the existing confirmations contained invalid blocks, the new confirmations are rebuilt from scratch
 	NewFork                 bool                       `json:"newFork,omitempty"`       // when true, it means a new fork was detected based on the existing confirmations

--- a/pkg/ethblocklistener/blocklistener.go
+++ b/pkg/ethblocklistener/blocklistener.go
@@ -545,9 +545,9 @@ func (bl *blockListener) trimToLastValidBlock() (lastValidBlock *ethrpc.BlockInf
 			// Trim everything after this point, as it's invalidated
 			nextElem := lastElem.Next()
 			for nextElem != nil {
-				toRemove := lastElem
-				nextElem = nextElem.Next()
-				_ = bl.canonicalChain.Remove(toRemove)
+				next := nextElem.Next()
+				_ = bl.canonicalChain.Remove(nextElem)
+				nextElem = next
 			}
 			break
 		}

--- a/pkg/ethblocklistener/blocklistener.go
+++ b/pkg/ethblocklistener/blocklistener.go
@@ -38,6 +38,23 @@ import (
 	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 )
 
+type ConfirmationUpdateResult struct {
+	Receipt *ethrpc.TxReceiptJSONRPC `json:"receipt,omitempty"` // receipt for the transaction
+	// a linked list of accumulated confirmations for a transaction
+	// the list is sorted by block number
+	//    - the first block is the block that contains the transaction hash
+	//    - the last block is the most recent confirmation
+	// this list can be used as input to the future reconcile request to avoid re-fetching the blocks if they are no longer
+	// in the in-memory partial chain
+	// WARNING: mutation to this list is not expected, invalid modifications will cause inefficiencies in the reconciliation process
+	//          `rebuilt` will be true if an invalid confirmation list is detected by the reconciliation process
+	Confirmations           []*ethrpc.MinimalBlockInfo `json:"confirmations,omitempty"`
+	Rebuilt                 bool                       `json:"rebuilt,omitempty"`       // when true, it means the existing confirmations contained invalid blocks, the new confirmations are rebuilt from scratch
+	NewFork                 bool                       `json:"newFork,omitempty"`       // when true, it means a new fork was detected based on the existing confirmations
+	Confirmed               bool                       `json:"confirmed,omitempty"`     // when true, it means the confirmation list is complete and the transaction is confirmed
+	TargetConfirmationCount uint64                     `json:"targetConfirmationCount"` // the target number of confirmations for this reconcile request
+}
+
 type BlockListenerConfig struct {
 	MonitoredHeadLength           int           `json:"monitoredHeadLength"`
 	BlockPollingInterval          time.Duration `json:"blockPollingInterval"`
@@ -49,7 +66,7 @@ type BlockListenerConfig struct {
 }
 
 type BlockListener interface {
-	ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ffcapi.MinimalBlockInfo, targetConfirmationCount uint64) (*ffcapi.ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error)
+	ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ethrpc.MinimalBlockInfo, targetConfirmationCount uint64) (*ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error)
 	GetMonitoredHeadLength() int // provides a getter on the configuration for unstable head length - as this information is important to consumers (might be multiple from this block listener)
 	AddConsumer(ctx context.Context, c *BlockUpdateConsumer)
 	RemoveConsumer(ctx context.Context, id *fftypes.UUID)
@@ -67,10 +84,10 @@ type BlockListener interface {
 	UTSetBackend(rpcbackend.RPC)
 }
 
-func ffcapiMinimalBlockInfoList(blocks []*ethrpc.BlockInfoJSONRPC) []*ffcapi.MinimalBlockInfo {
-	res := make([]*ffcapi.MinimalBlockInfo, len(blocks))
+func toMinimalBlockInfoList(blocks []*ethrpc.BlockInfoJSONRPC) []*ethrpc.MinimalBlockInfo {
+	res := make([]*ethrpc.MinimalBlockInfo, len(blocks))
 	for i, b := range blocks {
-		res[i] = b.ToFFCAPIMinimalBlockInfo()
+		res[i] = b.ToMinimalBlockInfo()
 	}
 	return res
 }

--- a/pkg/ethblocklistener/blocklistener_blockquery.go
+++ b/pkg/ethblocklistener/blocklistener_blockquery.go
@@ -31,7 +31,7 @@ func (bl *blockListener) addToBlockCache(blockInfo *ethrpc.BlockInfoJSONRPC) {
 	bl.blockCache.Add(blockInfo.Number.String(), blockInfo)
 }
 
-func (bl *blockListener) getBlockInfoContainsTxHash(ctx context.Context, txHash string) (*ethrpc.BlockInfoJSONRPC, *ethrpc.TxReceiptJSONRPC, error) {
+func (bl *blockListener) getReceiptAndBlock(ctx context.Context, txHash string) (*ethrpc.BlockInfoJSONRPC, *ethrpc.TxReceiptJSONRPC, error) {
 
 	// Query the chain to find the transaction block
 	receipt, receiptErr := bl.GetTransactionReceipt(ctx, txHash)

--- a/pkg/ethblocklistener/confirmation_reconciler.go
+++ b/pkg/ethblocklistener/confirmation_reconciler.go
@@ -26,26 +26,21 @@ import (
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 )
 
-func toBlockInfoList(ffcapiBlocks []*ethrpc.MinimalBlockInfo) (blocks []*ethrpc.BlockInfoJSONRPC, err error) {
+func toBlockInfoList(ffcapiBlocks []*ethrpc.MinimalBlockInfo) (blocks []*ethrpc.BlockInfoJSONRPC) {
 	blocks = make([]*ethrpc.BlockInfoJSONRPC, len(ffcapiBlocks))
 	for i, b := range ffcapiBlocks {
-		blocks[i] = &ethrpc.BlockInfoJSONRPC{Number: ethtypes.HexUint64(b.BlockNumber)}
-		if err == nil {
-			blocks[i].Hash, err = ethtypes.NewHexBytes0xPrefix(b.BlockHash)
-		}
-		if err == nil {
-			blocks[i].ParentHash, err = ethtypes.NewHexBytes0xPrefix(b.ParentHash)
+		blocks[i] = &ethrpc.BlockInfoJSONRPC{
+			Number:     ethtypes.HexUint64(b.BlockNumber),
+			Hash:       b.BlockHash,
+			ParentHash: b.ParentHash,
 		}
 	}
-	return blocks, err
+	return blocks
 }
 
 func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ethrpc.MinimalBlockInfo, targetConfirmationCount uint64) (*ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error) {
 
-	blockInfoExistingConfirmations, err := toBlockInfoList(existingConfirmations)
-	if err != nil {
-		return nil, nil, err
-	}
+	blockInfoExistingConfirmations := toBlockInfoList(existingConfirmations)
 
 	// Fetch the block containing the transaction first so that we can use it to build the confirmation list
 	txBlockInfo, txReceipt, err := bl.getBlockInfoContainsTxHash(ctx, txHash)

--- a/pkg/ethblocklistener/confirmation_reconciler.go
+++ b/pkg/ethblocklistener/confirmation_reconciler.go
@@ -43,7 +43,7 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 	blockInfoExistingConfirmations := toBlockInfoList(existingConfirmations)
 
 	// Fetch the block containing the transaction first so that we can use it to build the confirmation list
-	txBlockInfo, txReceipt, err := bl.getBlockInfoContainsTxHash(ctx, txHash)
+	txBlockInfo, txReceipt, err := bl.getReceiptAndBlock(ctx, txHash)
 	if err != nil {
 		log.L(ctx).Errorf("Failed to fetch block info using tx hash %s: %v", txHash, err)
 		return nil, nil, err
@@ -84,10 +84,10 @@ func (bl *blockListener) buildConfirmationList(ctx context.Context, existingConf
 	//    The chain may have been re-organized since we discovered the blocks in that list.
 	// - The `lateList`. This is the most recent set of blocks that we are interesting in and we believe are accurate for the current state of the chain
 
-	earlyList := createEarlyList(existingConfirmations, txBlockInfo, reconcileResult)
+	earlyList := createPreSpliceEarlyList(existingConfirmations, txBlockInfo, reconcileResult) // ensured to have at least one entry
 
 	// if early list is sufficient to meet the target confirmation count, we handle this as a special case as well
-	if len(earlyList) > 0 && earlyList[len(earlyList)-1].Number.Uint64() >= txBlockInfo.Number.Uint64()+targetConfirmationCount {
+	if earlyList[len(earlyList)-1].Number.Uint64() >= txBlockInfo.Number.Uint64()+targetConfirmationCount {
 		reconcileResult := bl.handleTargetCountMetWithEarlyList(earlyList, targetConfirmationCount)
 		if reconcileResult != nil {
 			return reconcileResult, nil
@@ -172,6 +172,7 @@ func newSplice(earlyList []*ethrpc.BlockInfoJSONRPC, lateList []*ethrpc.BlockInf
 			}
 		}
 
+		// We're in a if-block that confirms this will be at least one entry (no we never trim early list to zero)
 		s.earlyList = s.earlyList[:firstLateBlockNumber-txBlockNumber]
 	}
 	return s, detectedFork
@@ -225,9 +226,9 @@ func (s *splice) toSingleLinkedList() []*ethrpc.BlockInfoJSONRPC {
 
 }
 
-// createEarlyList will return a list of blocks that starts with the latest transaction block and followed by any blocks in the existing confirmations list that are still valid
+// createPreSpliceEarlyList will return a list of blocks that starts with the latest transaction block and followed by any blocks in the existing confirmations list that are still valid
 // any blocks that are not contiguous will be discarded
-func createEarlyList(existingConfirmations []*ethrpc.BlockInfoJSONRPC, txBlockInfo *ethrpc.BlockInfoJSONRPC, reconcileResult *ConfirmationUpdateResult) (earlyList []*ethrpc.BlockInfoJSONRPC) {
+func createPreSpliceEarlyList(existingConfirmations []*ethrpc.BlockInfoJSONRPC, txBlockInfo *ethrpc.BlockInfoJSONRPC, reconcileResult *ConfirmationUpdateResult) (earlyList []*ethrpc.BlockInfoJSONRPC) {
 	if len(existingConfirmations) > 0 {
 		if !existingConfirmations[0].Equal(txBlockInfo) {
 			// we discard the existing confirmations list if the transaction block doesn't match

--- a/pkg/ethblocklistener/confirmation_reconciler.go
+++ b/pkg/ethblocklistener/confirmation_reconciler.go
@@ -24,10 +24,9 @@ import (
 	"github.com/hyperledger/firefly-evmconnect/internal/msgs"
 	"github.com/hyperledger/firefly-evmconnect/pkg/ethrpc"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
-	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 )
 
-func ffcapiToBlockInfoList(ffcapiBlocks []*ffcapi.MinimalBlockInfo) (blocks []*ethrpc.BlockInfoJSONRPC, err error) {
+func toBlockInfoList(ffcapiBlocks []*ethrpc.MinimalBlockInfo) (blocks []*ethrpc.BlockInfoJSONRPC, err error) {
 	blocks = make([]*ethrpc.BlockInfoJSONRPC, len(ffcapiBlocks))
 	for i, b := range ffcapiBlocks {
 		blocks[i] = &ethrpc.BlockInfoJSONRPC{Number: ethtypes.HexUint64(b.BlockNumber)}
@@ -41,12 +40,9 @@ func ffcapiToBlockInfoList(ffcapiBlocks []*ffcapi.MinimalBlockInfo) (blocks []*e
 	return blocks, err
 }
 
-// reconcileConfirmationsForTransaction reconciles the confirmation queue for a transaction
-//
-// For historical reasons this interface is FFCAPI derived MinimalBlockInfo in/out, rather than direct.
-func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, ffcapiExistingConfirmations []*ffcapi.MinimalBlockInfo, targetConfirmationCount uint64) (*ffcapi.ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error) {
+func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Context, txHash string, existingConfirmations []*ethrpc.MinimalBlockInfo, targetConfirmationCount uint64) (*ConfirmationUpdateResult, *ethrpc.TxReceiptJSONRPC, error) {
 
-	existingConfirmations, err := ffcapiToBlockInfoList(ffcapiExistingConfirmations)
+	blockInfoExistingConfirmations, err := toBlockInfoList(existingConfirmations)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -62,7 +58,7 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 		log.L(ctx).Debugf("Transaction %s not found in any block", txHash)
 		return nil, nil, i18n.NewError(ctx, msgs.MsgTransactionNotFound, txHash)
 	}
-	confirmationUpdateResult, err := bl.buildConfirmationList(ctx, existingConfirmations, txBlockInfo, targetConfirmationCount)
+	confirmationUpdateResult, err := bl.buildConfirmationList(ctx, blockInfoExistingConfirmations, txBlockInfo, targetConfirmationCount)
 	if confirmationUpdateResult != nil {
 		confirmationUpdateResult.TargetConfirmationCount = targetConfirmationCount
 		// NOTE: This function does not do the full receipt decoding, for which there is a complex function for.
@@ -71,7 +67,7 @@ func (bl *blockListener) ReconcileConfirmationsForTransaction(ctx context.Contex
 	return confirmationUpdateResult, txReceipt, err
 }
 
-func (bl *blockListener) buildConfirmationList(ctx context.Context, existingConfirmations []*ethrpc.BlockInfoJSONRPC, txBlockInfo *ethrpc.BlockInfoJSONRPC, targetConfirmationCount uint64) (*ffcapi.ConfirmationUpdateResult, error) {
+func (bl *blockListener) buildConfirmationList(ctx context.Context, existingConfirmations []*ethrpc.BlockInfoJSONRPC, txBlockInfo *ethrpc.BlockInfoJSONRPC, targetConfirmationCount uint64) (*ConfirmationUpdateResult, error) {
 	// Primary objective of this algorithm is to build a contiguous, linked list of `MinimalBlockInfo` structs, starting from the transaction block and ending as far as our current knowledge of the in-memory partial canonical chain allows.
 	// Secondary objective is to report whether any fork was detected (and corrected) during this analysis
 
@@ -84,7 +80,7 @@ func (bl *blockListener) buildConfirmationList(ctx context.Context, existingConf
 	}
 
 	// Initialize the result with the target confirmation count
-	reconcileResult := &ffcapi.ConfirmationUpdateResult{}
+	reconcileResult := &ConfirmationUpdateResult{}
 
 	// We start by constructing 2 lists of blocks:
 	// - The `earlyList`.  This is the set of earliest blocks we are interested in.  At the least, it starts with the transaction block
@@ -135,7 +131,7 @@ func (bl *blockListener) buildConfirmationList(ctx context.Context, existingConf
 		if confirmations != nil {
 			// we have a contiguous list that starts with the transaction block and ends with the last block in the canonical chain
 			// so we can return the result
-			reconcileResult.Confirmations = ffcapiMinimalBlockInfoList(confirmations)
+			reconcileResult.Confirmations = toMinimalBlockInfoList(confirmations)
 			break
 		}
 
@@ -236,7 +232,7 @@ func (s *splice) toSingleLinkedList() []*ethrpc.BlockInfoJSONRPC {
 
 // createEarlyList will return a list of blocks that starts with the latest transaction block and followed by any blocks in the existing confirmations list that are still valid
 // any blocks that are not contiguous will be discarded
-func createEarlyList(existingConfirmations []*ethrpc.BlockInfoJSONRPC, txBlockInfo *ethrpc.BlockInfoJSONRPC, reconcileResult *ffcapi.ConfirmationUpdateResult) (earlyList []*ethrpc.BlockInfoJSONRPC) {
+func createEarlyList(existingConfirmations []*ethrpc.BlockInfoJSONRPC, txBlockInfo *ethrpc.BlockInfoJSONRPC, reconcileResult *ConfirmationUpdateResult) (earlyList []*ethrpc.BlockInfoJSONRPC) {
 	if len(existingConfirmations) > 0 {
 		if !existingConfirmations[0].Equal(txBlockInfo) {
 			// we discard the existing confirmations list if the transaction block doesn't match
@@ -340,7 +336,7 @@ func (bl *blockListener) buildConfirmationQueueUsingInMemoryPartialChain(ctx con
 	return newConfirmationsWithoutTxBlock, nil
 }
 
-func (bl *blockListener) handleZeroTargetConfirmationCount(ctx context.Context, txBlockInfo *ethrpc.BlockInfoJSONRPC) (*ffcapi.ConfirmationUpdateResult, error) {
+func (bl *blockListener) handleZeroTargetConfirmationCount(ctx context.Context, txBlockInfo *ethrpc.BlockInfoJSONRPC) (*ConfirmationUpdateResult, error) {
 	bl.canonicalChainLock.RLock()
 	defer bl.canonicalChainLock.RUnlock()
 	// if the target confirmation count is 0, and the transaction blocks is before the last block in the in-memory partial chain,
@@ -351,14 +347,14 @@ func (bl *blockListener) handleZeroTargetConfirmationCount(ctx context.Context, 
 		return nil, err
 	}
 
-	return &ffcapi.ConfirmationUpdateResult{
+	return &ConfirmationUpdateResult{
 		Confirmed:     true,
-		Confirmations: []*ffcapi.MinimalBlockInfo{txBlockInfo.ToFFCAPIMinimalBlockInfo()},
+		Confirmations: []*ethrpc.MinimalBlockInfo{txBlockInfo.ToMinimalBlockInfo()},
 	}, nil
 
 }
 
-func (bl *blockListener) handleTargetCountMetWithEarlyList(existingConfirmations []*ethrpc.BlockInfoJSONRPC, targetConfirmationCount uint64) *ffcapi.ConfirmationUpdateResult {
+func (bl *blockListener) handleTargetCountMetWithEarlyList(existingConfirmations []*ethrpc.BlockInfoJSONRPC, targetConfirmationCount uint64) *ConfirmationUpdateResult {
 	bl.canonicalChainLock.RLock()
 	defer bl.canonicalChainLock.RUnlock()
 	nextInMemoryBlock := bl.canonicalChain.Front()
@@ -375,9 +371,9 @@ func (bl *blockListener) handleTargetCountMetWithEarlyList(existingConfirmations
 
 	if nextInMemoryBlockInfo != nil && lastExistingConfirmation.IsParentOf(nextInMemoryBlockInfo) {
 		// the existing confirmation are connected to the in memory partial chain so we can return them without fetching any more blocks
-		return &ffcapi.ConfirmationUpdateResult{
+		return &ConfirmationUpdateResult{
 			Confirmed:     true,
-			Confirmations: ffcapiMinimalBlockInfoList(existingConfirmations[:targetConfirmationCount+1]),
+			Confirmations: toMinimalBlockInfoList(existingConfirmations[:targetConfirmationCount+1]),
 		}
 	}
 	return nil

--- a/pkg/ethblocklistener/confirmation_reconciler_test.go
+++ b/pkg/ethblocklistener/confirmation_reconciler_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/hyperledger/firefly-evmconnect/pkg/ethrpc"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
 	"github.com/hyperledger/firefly-signer/pkg/rpcbackend"
-	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -104,7 +103,7 @@ func TestReconcileConfirmationsForTransaction_ReceiptRPCCallError(t *testing.T) 
 	})
 
 	// Execute the reconcileConfirmationsForTransaction function
-	result, _, err := bl.ReconcileConfirmationsForTransaction(context.Background(), generateTestHash(100).String(), []*ffcapi.MinimalBlockInfo{}, 5)
+	result, _, err := bl.ReconcileConfirmationsForTransaction(context.Background(), generateTestHash(100).String(), []*ethrpc.MinimalBlockInfo{}, 5)
 
 	// Assertions - expect an error when RPC call fails
 	assert.Error(t, err)
@@ -133,7 +132,7 @@ func TestReconcileConfirmationsForTransaction_BlockNotFound(t *testing.T) {
 
 	// Execute the reconcileConfirmationsForTransaction function
 	result, _, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6",
-		ffcapiMinimalBlockInfoList([]*ethrpc.BlockInfoJSONRPC{
+		toMinimalBlockInfoList([]*ethrpc.BlockInfoJSONRPC{
 			{Number: 1977, Hash: generateTestHash(1977), ParentHash: generateTestHash(1976)},
 		}), 5)
 
@@ -160,7 +159,7 @@ func TestReconcileConfirmationsForTransaction_BlockRPCCallError(t *testing.T) {
 	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByNumber", "0x7b9", false).Return(&rpcbackend.RPCError{Message: "pop"})
 
 	// Execute the reconcileConfirmationsForTransaction function
-	result, _, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6", []*ffcapi.MinimalBlockInfo{}, 5)
+	result, _, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6", []*ethrpc.MinimalBlockInfo{}, 5)
 
 	// Assertions - expect an error when RPC call fails
 	assert.Error(t, err)
@@ -192,7 +191,7 @@ func TestReconcileConfirmationsForTransaction_TxBlockNotInCanonicalChain(t *test
 	})
 
 	// Execute the reconcileConfirmationsForTransaction function
-	result, receipt, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6", []*ffcapi.MinimalBlockInfo{}, 5)
+	result, receipt, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6", []*ethrpc.MinimalBlockInfo{}, 5)
 
 	// Assertions - expect the transaction block to be returned
 	// we trust the block retrieve by getBlockInfoContainsTxHash function more than the canonical chain
@@ -232,14 +231,14 @@ func TestReconcileConfirmationsForTransaction_NewConfirmation(t *testing.T) {
 	})
 
 	// Execute the reconcileConfirmationsForTransaction function
-	result, receipt, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6", []*ffcapi.MinimalBlockInfo{}, 5)
+	result, receipt, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6", []*ethrpc.MinimalBlockInfo{}, 5)
 
 	// Assertions - expect the existing confirmation queue to be returned because the tx block doesn't match the same block number in the canonical chain
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.False(t, result.NewFork)
 	assert.False(t, result.Confirmed)
-	assert.Equal(t, ffcapiMinimalBlockInfoList([]*ethrpc.BlockInfoJSONRPC{
+	assert.Equal(t, toMinimalBlockInfoList([]*ethrpc.BlockInfoJSONRPC{
 		{Number: 1977, Hash: generateTestHash(1977), ParentHash: generateTestHash(1976)},
 		{Number: 1978, Hash: generateTestHash(1978), ParentHash: generateTestHash(1977)},
 	}), result.Confirmations)
@@ -273,7 +272,7 @@ func TestReconcileConfirmationsForTransaction_DifferentTxBlock(t *testing.T) {
 
 	// Execute the reconcileConfirmationsForTransaction function
 	result, receipt, err := bl.ReconcileConfirmationsForTransaction(context.Background(), "0x6197ef1a58a2a592bb447efb651f0db7945de21aa8048801b250bd7b7431f9b6",
-		ffcapiMinimalBlockInfoList([]*ethrpc.BlockInfoJSONRPC{
+		toMinimalBlockInfoList([]*ethrpc.BlockInfoJSONRPC{
 			{Number: 1979, Hash: generateTestHash(1979), ParentHash: generateTestHash(1978)},
 			{Number: 1980, Hash: generateTestHash(1980), ParentHash: generateTestHash(1979)},
 		}), 5)
@@ -283,7 +282,7 @@ func TestReconcileConfirmationsForTransaction_DifferentTxBlock(t *testing.T) {
 	assert.NotNil(t, result)
 	assert.True(t, result.NewFork)
 	assert.False(t, result.Confirmed)
-	assert.Equal(t, ffcapiMinimalBlockInfoList([]*ethrpc.BlockInfoJSONRPC{
+	assert.Equal(t, toMinimalBlockInfoList([]*ethrpc.BlockInfoJSONRPC{
 		{Number: 1977, Hash: generateTestHash(1977), ParentHash: generateTestHash(1976)},
 		{Number: 1978, Hash: generateTestHash(1978), ParentHash: generateTestHash(1977)},
 	}), result.Confirmations)

--- a/pkg/ethblocklistener/confirmation_reconciler_test.go
+++ b/pkg/ethblocklistener/confirmation_reconciler_test.go
@@ -329,6 +329,106 @@ func TestBuildConfirmationList_GapInExistingConfirmationsShouldBeFilledIn(t *tes
 
 }
 
+func TestBuildConfirmationList_EarlyListDrainsToEmptyDueToMismatch(t *testing.T) {
+	ctx := context.Background()
+
+	const altBlock = 0xffff
+
+	chain := list.New()
+	chain.PushBack(&ethrpc.BlockInfoJSONRPC{
+		Number:     ethtypes.HexUint64(100),
+		Hash:       generateTestHash(100),
+		ParentHash: generateTestHash(99),
+	})
+	mRPC, bl := newFakedChainBlockListener(t, chain)
+	mockBlockRange(mRPC, 100, 105, altBlock)
+
+	// Create corrupted confirmation (gap in the existing confirmations list)
+	existingQueue := []*ethrpc.BlockInfoJSONRPC{}
+	txBlockNumber := uint64(100)
+	txBlockHash := generateTestHash(100)
+	txBlockInfo := &ethrpc.BlockInfoJSONRPC{
+		Number:     ethtypes.HexUint64(txBlockNumber),
+		Hash:       txBlockHash,
+		ParentHash: generateTestHash(99),
+	}
+	targetConfirmationCount := uint64(5)
+
+	// Execute
+	_, err := bl.buildConfirmationList(ctx, existingQueue, txBlockInfo, targetConfirmationCount)
+	assert.Regexp(t, "FF23060", err)
+}
+
+func TestBuildConfirmationList_EarlyFillInFail(t *testing.T) {
+	ctx := context.Background()
+
+	chain := list.New()
+	chain.PushBack(&ethrpc.BlockInfoJSONRPC{
+		Number:     ethtypes.HexUint64(100),
+		Hash:       generateTestHash(100),
+		ParentHash: generateTestHash(99),
+	})
+	mRPC, bl := newFakedChainBlockListener(t, chain)
+	mockBlockRange(mRPC, 102, 105)
+
+	mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByNumber", "0x65", false).
+		Return(&rpcbackend.RPCError{Message: "pop"})
+
+	// Create corrupted confirmation (gap in the existing confirmations list)
+	existingQueue := []*ethrpc.BlockInfoJSONRPC{
+		{Hash: generateTestHash(100), Number: 100, ParentHash: generateTestHash(99)},
+		// gap in the existing confirmations list
+		{Hash: generateTestHash(102), Number: 102, ParentHash: generateTestHash(101)},
+	}
+	txBlockNumber := uint64(100)
+	txBlockHash := generateTestHash(100)
+	txBlockInfo := &ethrpc.BlockInfoJSONRPC{
+		Number:     ethtypes.HexUint64(txBlockNumber),
+		Hash:       txBlockHash,
+		ParentHash: generateTestHash(99),
+	}
+	targetConfirmationCount := uint64(5)
+
+	// Execute
+	_, err := bl.buildConfirmationList(ctx, existingQueue, txBlockInfo, targetConfirmationCount)
+	assert.Regexp(t, "pop", err)
+}
+
+func TestBuildConfirmationList_EarlyFillInInvalid(t *testing.T) {
+	ctx := context.Background()
+
+	chain := list.New()
+	chain.PushBack(&ethrpc.BlockInfoJSONRPC{
+		Number:     ethtypes.HexUint64(100),
+		Hash:       generateTestHash(100),
+		ParentHash: generateTestHash(99),
+	})
+	mRPC, bl := newFakedChainBlockListener(t, chain)
+	mockBlockRange(mRPC, 102, 105)
+
+	var altBlock uint64 = 0xffff
+	mockBlockRange(mRPC, 101, 101, altBlock)
+
+	// Create corrupted confirmation (gap in the existing confirmations list)
+	existingQueue := []*ethrpc.BlockInfoJSONRPC{
+		{Hash: generateTestHash(100), Number: 100, ParentHash: generateTestHash(99)},
+		// gap in the existing confirmations list
+		{Hash: generateTestHash(102), Number: 102, ParentHash: generateTestHash(101)},
+	}
+	txBlockNumber := uint64(100)
+	txBlockHash := generateTestHash(100)
+	txBlockInfo := &ethrpc.BlockInfoJSONRPC{
+		Number:     ethtypes.HexUint64(txBlockNumber),
+		Hash:       txBlockHash,
+		ParentHash: generateTestHash(99),
+	}
+	targetConfirmationCount := uint64(5)
+
+	// Execute
+	_, err := bl.buildConfirmationList(ctx, existingQueue, txBlockInfo, targetConfirmationCount)
+	assert.Regexp(t, "FF23060", err)
+}
+
 func TestBuildConfirmationList_MismatchConfirmationBlockShouldBeReplaced(t *testing.T) {
 	// Setup
 	bl, done := newBlockListenerWithTestChain(t, 100, 5, 102, 150, []uint64{101})
@@ -1254,8 +1354,12 @@ func TestBuildConfirmationList_ReachTargetConfirmation(t *testing.T) {
 // Helper functions
 
 // generateTestHash creates a predictable hash for testing with consistent prefix and last 4 digits as index
-func generateTestHash(index uint64) ethtypes.HexBytes0xPrefix {
-	return ethtypes.MustNewHexBytes0xPrefix(fmt.Sprintf("0x%060x", index))
+func generateTestHash(index uint64, mods ...uint64) ethtypes.HexBytes0xPrefix {
+	val := index
+	for _, mod := range mods {
+		val += mod * 10000000000 // tweaks the number, while still recognizable
+	}
+	return ethtypes.MustNewHexBytes0xPrefix(fmt.Sprintf("0x%060x", val))
 }
 
 func createTestChain(startBlock, endBlock uint64) *list.List {
@@ -1281,13 +1385,19 @@ func createTestChain(startBlock, endBlock uint64) *list.List {
 	return chain
 }
 
-func newBlockListenerWithTestChain(t *testing.T, txBlock, confirmationCount, startCanonicalBlock, endCanonicalBlock uint64, blocksToMock []uint64) (*blockListener, func()) {
-	mRPC := &rpcbackendmocks.Backend{}
+func newFakedChainBlockListener(t *testing.T, chain *list.List) (*rpcbackendmocks.Backend, *blockListener) {
+	mRPC := rpcbackendmocks.NewBackend(t)
+	blockCache, _ := lru.New(100)
 	bl := &blockListener{
-		canonicalChain: createTestChain(startCanonicalBlock, endCanonicalBlock),
+		canonicalChain: chain,
 		backend:        mRPC,
+		blockCache:     blockCache,
 	}
-	bl.blockCache, _ = lru.New(100)
+	return mRPC, bl
+}
+
+func newBlockListenerWithTestChain(t *testing.T, txBlock, confirmationCount, startCanonicalBlock, endCanonicalBlock uint64, blocksToMock []uint64) (*blockListener, func()) {
+	mRPC, bl := newFakedChainBlockListener(t, createTestChain(startCanonicalBlock, endCanonicalBlock))
 
 	if len(blocksToMock) > 0 {
 		for _, blockNumber := range blocksToMock {
@@ -1303,5 +1413,18 @@ func newBlockListenerWithTestChain(t *testing.T, txBlock, confirmationCount, sta
 	}
 	return bl, func() {
 		mRPC.AssertExpectations(t)
+	}
+}
+
+func mockBlockRange(mRPC *rpcbackendmocks.Backend, start, end uint64, mods ...uint64) {
+	for blockNumber := start; blockNumber <= end; blockNumber++ {
+		hexBlockNumber := ethtypes.HexUint64(blockNumber)
+		mRPC.On("CallRPC", mock.Anything, mock.Anything, "eth_getBlockByNumber", hexBlockNumber.String(), false).Return(nil).Run(func(args mock.Arguments) {
+			*args[1].(**ethrpc.EVMBlockWithTxHashesJSONRPC) = &ethrpc.EVMBlockWithTxHashesJSONRPC{BlockHeaderJSONRPC: ethrpc.BlockHeaderJSONRPC{
+				Number:     ethtypes.HexUint64(blockNumber),
+				Hash:       generateTestHash(blockNumber, mods...),
+				ParentHash: generateTestHash(blockNumber-1, mods...),
+			}}
+		}).Maybe()
 	}
 }

--- a/pkg/ethrpc/ethrpc.go
+++ b/pkg/ethrpc/ethrpc.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/hyperledger/firefly-common/pkg/fftypes"
 	"github.com/hyperledger/firefly-signer/pkg/ethtypes"
-	"github.com/hyperledger/firefly-transaction-manager/pkg/ffcapi"
 )
 
 // TxReceiptJSONRPC is the receipt obtained over JSON/RPC from the ethereum client, with gas used, logs and contract address
@@ -198,12 +197,26 @@ func (bi *BlockInfoJSONRPC) IsParentOf(other *BlockInfoJSONRPC) bool {
 	return bi.Hash.Equals(other.ParentHash) && (bi.Number.Uint64()+1) == other.Number.Uint64()
 }
 
-func (bi *BlockInfoJSONRPC) ToFFCAPIMinimalBlockInfo() *ffcapi.MinimalBlockInfo {
-	return &ffcapi.MinimalBlockInfo{
+type MinimalBlockInfo struct { // duplicate of apitypes.Confirmation due to circular dependency
+	BlockNumber fftypes.FFuint64 `json:"blockNumber"`
+	BlockHash   string           `json:"blockHash"`
+	ParentHash  string           `json:"parentHash"`
+}
+
+func (bi *BlockInfoJSONRPC) ToMinimalBlockInfo() *MinimalBlockInfo {
+	return &MinimalBlockInfo{
 		BlockNumber: fftypes.FFuint64(bi.Number.Uint64()),
 		BlockHash:   bi.Hash.String(),
 		ParentHash:  bi.ParentHash.String(),
 	}
+}
+
+func (c *MinimalBlockInfo) Equal(other *MinimalBlockInfo) bool {
+	return c.BlockNumber == other.BlockNumber && c.BlockHash == other.BlockHash && c.ParentHash == other.ParentHash
+}
+
+func (c *MinimalBlockInfo) IsParentOf(other *MinimalBlockInfo) bool {
+	return c.BlockHash == other.ParentHash && c.BlockNumber+1 == other.BlockNumber
 }
 
 type BlockHeaderJSONRPC struct {

--- a/pkg/ethrpc/ethrpc.go
+++ b/pkg/ethrpc/ethrpc.go
@@ -198,25 +198,25 @@ func (bi *BlockInfoJSONRPC) IsParentOf(other *BlockInfoJSONRPC) bool {
 }
 
 type MinimalBlockInfo struct { // duplicate of apitypes.Confirmation due to circular dependency
-	BlockNumber fftypes.FFuint64 `json:"blockNumber"`
-	BlockHash   string           `json:"blockHash"`
-	ParentHash  string           `json:"parentHash"`
+	BlockNumber fftypes.FFuint64          `json:"blockNumber"`
+	BlockHash   ethtypes.HexBytes0xPrefix `json:"blockHash"`
+	ParentHash  ethtypes.HexBytes0xPrefix `json:"parentHash"`
 }
 
 func (bi *BlockInfoJSONRPC) ToMinimalBlockInfo() *MinimalBlockInfo {
 	return &MinimalBlockInfo{
 		BlockNumber: fftypes.FFuint64(bi.Number.Uint64()),
-		BlockHash:   bi.Hash.String(),
-		ParentHash:  bi.ParentHash.String(),
+		BlockHash:   bi.Hash,
+		ParentHash:  bi.ParentHash,
 	}
 }
 
 func (c *MinimalBlockInfo) Equal(other *MinimalBlockInfo) bool {
-	return c.BlockNumber == other.BlockNumber && c.BlockHash == other.BlockHash && c.ParentHash == other.ParentHash
+	return c.BlockNumber == other.BlockNumber && c.BlockHash.Equals(other.BlockHash) && c.ParentHash.Equals(other.ParentHash)
 }
 
 func (c *MinimalBlockInfo) IsParentOf(other *MinimalBlockInfo) bool {
-	return c.BlockHash == other.ParentHash && c.BlockNumber+1 == other.BlockNumber
+	return c.BlockHash.Equals(other.ParentHash) && c.BlockNumber+1 == other.BlockNumber
 }
 
 type BlockHeaderJSONRPC struct {

--- a/pkg/ethrpc/ethrpc_test.go
+++ b/pkg/ethrpc/ethrpc_test.go
@@ -226,9 +226,11 @@ func TestFormatBlockFullWithHashes(t *testing.T) {
 	require.JSONEq(t, sampleBlock, string(ethSerialized))
 
 	require.NotNil(t, block.ToBlockInfo(true))
-	require.NotNil(t, block.ToBlockInfo(true).ToFFCAPIMinimalBlockInfo())
+	require.NotNil(t, block.ToBlockInfo(true).ToMinimalBlockInfo())
 	require.True(t, block.ToBlockInfo(true).Equal(block.ToBlockInfo(true)))
+	require.True(t, block.ToBlockInfo(true).ToMinimalBlockInfo().Equal(block.ToBlockInfo(true).ToMinimalBlockInfo()))
 	require.Nil(t, (*EVMBlockWithTxHashesJSONRPC)(nil).ToBlockInfo(true))
+	require.False(t, block.ToBlockInfo(true).ToMinimalBlockInfo().IsParentOf(block.ToBlockInfo(true).ToMinimalBlockInfo()))
 }
 
 func TestFormatBlockFullWithTxns(t *testing.T) {


### PR DESCRIPTION
We ended up between two stools on our `ReconcileConfirmationsForTransaction` API, where if you used it directly via `ethblocklistener` you were still exposed to some types from `ffcapi`.

This PR fully cleans up the separation.