### PR TITLE
chore: update CODEOWNERS for hyperledger-firefly org migration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: Apache-2.0
 
-* @hyperledger/firefly-evmconnect-maintainers
+* @hyperledger-firefly/firefly-evmconnect-maintainers


### PR DESCRIPTION
Updates the CODEOWNERS file to reference the `hyperledger-firefly` GitHub organisation instead of `hyperledger` following repo migration.