### PR TITLE
Pin minor version of golang in Dockerfile and workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.26.0"
+          go-version: "1.26"
 
       - name: Build and Test
         run: make

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.0-alpine3.23 AS builder
+FROM golang:1.26-alpine3.23 AS builder
 RUN apk add --no-cache make git
 ARG BUILD_VERSION
 ENV BUILD_VERSION=${BUILD_VERSION}


### PR DESCRIPTION
Pin minor version of golang in Dockerfile and workflow so we pick up CVEs on rebuild