### PR TITLE
fix: restore group 0 as primary group for runtime user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN DB_MIGRATIONS_DIR=$(go list -f '{{.Dir}}' github.com/hyperledger-firefly/tra
 
 FROM alpine:3.21.3
 WORKDIR /evmconnect
-RUN addgroup -g 1001 evmgroup && adduser -D -u 1001 -G evmgroup evmuser
 RUN chgrp -R 0 /evmconnect \
   && chmod -R g+rwX /evmconnect
 RUN apk add --no-cache curl jq


### PR DESCRIPTION
PR #173 added an explicit passwd entry for uid 1001 with primary group 1001 (evmgroup). Previously the bare 'USER 1001' had no passwd entry, so the runtime user's primary group defaulted to 0 (root).

The FireFly CLI initializes the evmconnect data volume with 'chgrp -R 0 && chmod -R g+rwX' (the group-0 convention, matching the ADD/COPY --chown=1001:0 lines in this Dockerfile), so a runtime user outside group 0 can no longer write to it. Every release since v1.4.1 fails against a CLI-created stack with: